### PR TITLE
fixed missing include in lpcplex.hxx

### DIFF
--- a/include/opengm/inference/lpcplex.hxx
+++ b/include/opengm/inference/lpcplex.hxx
@@ -15,6 +15,7 @@
 #include "opengm/opengm.hxx"
 #include "opengm/operations/adder.hxx"
 #include "opengm/operations/minimizer.hxx"
+#include "opengm/operations/maximizer.hxx"
 #include "opengm/inference/inference.hxx"
 #include "opengm/inference/visitors/visitor.hxx"
 


### PR DESCRIPTION
"#include "opengm/operations/maximizer.hxx" was missing in lpcplex.hxx leading to a compilation error:
error: 'Maximizer' is not a member of 'opengm'
