### PR TITLE
ASTAR factorMarginal and marginal used FactorType but must use IndependentFactorType

### DIFF
--- a/include/opengm/inference/astar.hxx
+++ b/include/opengm/inference/astar.hxx
@@ -126,8 +126,8 @@ namespace opengm {
       virtual void reset();
       template<class VisitorType> InferenceTermination infer(VisitorType& vistitor);
       ValueType bound()const {return belowBound_;}
-      virtual InferenceTermination marginal(const size_t,FactorType& out)const        {return UNKNOWN;}
-      virtual InferenceTermination factorMarginal(const size_t, FactorType& out)const {return UNKNOWN;}
+      virtual InferenceTermination marginal(const size_t,IndependentFactorType& out)const        {return UNKNOWN;}
+      virtual InferenceTermination factorMarginal(const size_t, IndependentFactorType& out)const {return UNKNOWN;}
       virtual InferenceTermination arg(std::vector<LabelType>& v, const size_t = 1)const;
       virtual InferenceTermination args(std::vector< std::vector<LabelType> >& v)const;
 


### PR DESCRIPTION
If an inference solver overwrites marginal and factor marginal one must use 
IndependentFactorType and not FactorType .
And astart could just not implement marginal and factor marginal sinde the impl. is the following:

InferenceTermination marginal(const size_t,IndependentFactorType& out)const
{return UNKNOWN;}

InferenceTermination factorMarginal(const size_t, IndependentFactorType& out)const 
{return UNKNOWN;}
