### PR TITLE
fix space labeltype

### DIFF
--- a/include/opengm/graphicalmodel/space/discretespace.hxx
+++ b/include/opengm/graphicalmodel/space/discretespace.hxx
@@ -24,13 +24,13 @@ public:
    template<class Iterator> DiscreteSpace(Iterator, Iterator);
    template<class Iterator> void assign(Iterator, Iterator);
    template<class Iterator> void assignDense(Iterator, Iterator);
-   IndexType addVariable(const IndexType);
+   IndexType addVariable(const LabelType);
    IndexType numberOfVariables() const;
-   IndexType numberOfLabels(const IndexType) const;
+   LabelType numberOfLabels(const IndexType) const;
    void reserve(const IndexType);
 
 private:
-   std::vector<IndexType> numbersOfLabels_;
+   std::vector<LabelType> numbersOfLabels_;
 };
 
 /// construct an empty label space (with zero variables)
@@ -104,7 +104,7 @@ template<class I, class L>
 inline typename DiscreteSpace<I, L>::IndexType
 DiscreteSpace<I, L>::addVariable
 (
-   const IndexType numberOfLabels
+   const LabelType numberOfLabels
 ) {
    numbersOfLabels_.push_back(numberOfLabels);
    OPENGM_ASSERT(std::numeric_limits<IndexType>::max()>numbersOfLabels_.size());
@@ -119,7 +119,7 @@ DiscreteSpace<I, L>::numberOfVariables() const
 }
 
 template<class I, class L>
-inline typename DiscreteSpace<I, L>::IndexType
+inline typename DiscreteSpace<I, L>::LabelType
 DiscreteSpace<I, L>::numberOfLabels
 (
    const IndexType dimension

--- a/include/opengm/graphicalmodel/space/simplediscretespace.hxx
+++ b/include/opengm/graphicalmodel/space/simplediscretespace.hxx
@@ -18,17 +18,17 @@ public:
    typedef L LabelType;
 
    SimpleDiscreteSpace();
-   SimpleDiscreteSpace(const IndexType, const IndexType);
-   void assign(const IndexType, const IndexType);
+   SimpleDiscreteSpace(const IndexType, const LabelType);
+   void assign(const IndexType, const LabelType);
    template<class Iterator> void assignDense(Iterator, Iterator);
-   IndexType addVariable(const IndexType);
+   IndexType addVariable(const LabelType);
    IndexType numberOfVariables() const;
-   IndexType numberOfLabels(const IndexType) const;
+   LabelType numberOfLabels(const IndexType) const;
    bool isSimpleSpace() const ;
 
 private:
    IndexType numberOfVariables_;
-   IndexType numberOfLabels_;
+   LabelType numberOfLabels_;
 };
 
 template<class I, class L>
@@ -43,7 +43,7 @@ inline
 SimpleDiscreteSpace<I, L>::SimpleDiscreteSpace
 (
    const IndexType numberOfVariables,
-   const IndexType numberOfLabels
+   const LabelType numberOfLabels
 )
 :  numberOfVariables_(numberOfVariables),
    numberOfLabels_(numberOfLabels)
@@ -60,7 +60,7 @@ SimpleDiscreteSpace<I, L>::assignDense
    numberOfVariables_ = std::distance(begin, end);
    numberOfLabels_ = static_cast<L>(*begin);
    while(begin != end) {
-      if(numberOfLabels_ != static_cast<IndexType>(*begin)) {
+      if(numberOfLabels_ != static_cast<LabelType>(*begin)) {
          throw opengm::RuntimeError("*begin == SimpleDiscreteSpace.numberOfLabels_ is violated in SimpleDiscreteSpace::assignDense");
       }
       ++begin;
@@ -72,7 +72,7 @@ inline void
 SimpleDiscreteSpace<I, L>::assign
 (
    const IndexType numberOfVariables,
-   const IndexType numberOfLabels
+   const LabelType numberOfLabels
 ) {
    numberOfVariables_ = numberOfVariables;
    numberOfLabels_ = numberOfLabels;
@@ -82,7 +82,7 @@ template<class I, class L>
 inline typename SimpleDiscreteSpace<I, L>::IndexType
 SimpleDiscreteSpace<I, L>::addVariable
 (
-   const IndexType numberOfLabels
+   const LabelType numberOfLabels
 ) {
    if(numberOfLabels != numberOfLabels_) {
       throw opengm::RuntimeError("numberOfLabels == SimpleDiscreteSpace.numberOfLabels_ is violated in SimpleDiscreteSpace::addVariable");
@@ -98,7 +98,7 @@ SimpleDiscreteSpace<I, L>::numberOfVariables() const {
 }
 
 template<class I, class L>
-inline typename SimpleDiscreteSpace<I, L>::IndexType
+inline typename SimpleDiscreteSpace<I, L>::LabelType
 SimpleDiscreteSpace<I, L>::numberOfLabels
 (
    const IndexType dimension

--- a/include/opengm/graphicalmodel/space/space_base.hxx
+++ b/include/opengm/graphicalmodel/space/space_base.hxx
@@ -18,9 +18,9 @@ public:
    typedef L LabelType;
 
    IndexType numberOfVariables() const; // must be implemented in Space
-   IndexType numberOfLabels(const IndexType) const; // must be implemented in Space
+   LabelType numberOfLabels(const IndexType) const; // must be implemented in Space
    template<class Iterator> void assignDense(Iterator, Iterator);
-   IndexType addVariable(const IndexType);
+   IndexType addVariable(const LabelType);
    bool isSimpleSpace() const;
 };
 
@@ -52,7 +52,7 @@ template<class SPACE, class I, class L>
 inline typename SpaceBase<SPACE, I, L>::IndexType
 SpaceBase<SPACE, I, L>::addVariable
 (
-   const IndexType numberOfLabels
+   const LabelType numberOfLabels
 ) {
    throw RuntimeError(std::string("assignDense(begin, end) is not implemented in ")+typeid(SPACE).name());
    return IndexType();

--- a/include/opengm/graphicalmodel/space/static_simplediscretespace.hxx
+++ b/include/opengm/graphicalmodel/space/static_simplediscretespace.hxx
@@ -22,9 +22,9 @@ public:
    StaticSimpleDiscreteSpace(const IndexType);
    void assign(const IndexType);
    template<class Iterator> void assignDense(Iterator, Iterator);
-   IndexType addVariable(const IndexType );
+   IndexType addVariable(const LabelType );
    IndexType numberOfVariables() const;
-   IndexType numberOfLabels(const IndexType) const;
+   LabelType numberOfLabels(const IndexType) const;
    bool isSimpleSpace()const;
 
 private:
@@ -89,11 +89,11 @@ StaticSimpleDiscreteSpace<LABELS,I, L>::numberOfVariables() const {
 }
 
 template<size_t LABELS,class I, class L>
-inline typename StaticSimpleDiscreteSpace<LABELS,I, L>::IndexType
+inline typename StaticSimpleDiscreteSpace<LABELS,I, L>::LabelType
 StaticSimpleDiscreteSpace<LABELS,I, L>::numberOfLabels(
    const IndexType dimension
 ) const {
-   return LABELS;
+   return static_cast<L> LABELS;
 }
 
 template<size_t LABELS,class I, class L>

--- a/include/opengm/graphicalmodel/space/viewspace.hxx
+++ b/include/opengm/graphicalmodel/space/viewspace.hxx
@@ -26,9 +26,9 @@ public:
    ViewSpace();
    ViewSpace(const GM &);
    void assign(const GM &);
-   IndexType addVariable(const IndexType);
+   IndexType addVariable(const LabelType);
    IndexType numberOfVariables() const;
-   IndexType numberOfLabels(const IndexType) const;
+   LabelType numberOfLabels(const IndexType) const;
 
 private:
    SrcSpaceType const* space_;
@@ -60,7 +60,7 @@ ViewSpace<GM>::assign(
 template<class GM>
 inline typename  ViewSpace<GM>::IndexType
 ViewSpace<GM>::addVariable(
-   const IndexType numberOfLabels
+   const LabelType numberOfLabels
 )
 {
    opengm::RuntimeError("cannot add Variable with a ViewSpace as a space object");

--- a/src/interfaces/python/docsrc/source/conf.py
+++ b/src/interfaces/python/docsrc/source/conf.py
@@ -42,10 +42,10 @@ for a in sys.argv:
         outdir = '/' + a[len(match):]
         
         
-sys.path.insert(0,'/home/tbeier/build/DerThorsten/opengm/src/interfaces/python')
+sys.path.insert(0,'/export/home/jkappes/GIT/opengmRC2.1/opengm/build/src/interfaces/python')
 
 #import imp
-#opengm = imp.load_source('opengm', '/home/tbeier/build/DerThorsten/opengm/src/interfaces/python')
+#opengm = imp.load_source('opengm', '/export/home/jkappes/GIT/opengmRC2.1/opengm/build/src/interfaces/python')
 #import opengm
 
 #sys.path.insert(0,'/home/tbeier/build/opengm2.03/src/interfaces/python')


### PR DESCRIPTION
Make interfaces of space-classes correct. This has to be checked/done for all classes.

Possible side-effects that I observed:
- ADSAL test seemed to loop "forever" 
- pyReducedinference does not compile
