### PR TITLE
resolved clang compiler errors for test_dualdecomposition

### DIFF
--- a/src/unittest/inference/test_dualdecomposition.cxx
+++ b/src/unittest/inference/test_dualdecomposition.cxx
@@ -46,13 +46,13 @@ int test() {
       std::cout << "  * Tree-Decomposition ... " << std::endl;
       typename DualDecompositionType::Parameter para;
       para.decompositionId_= DualDecompositionType::Parameter::TREE;
-      tester.test<DualDecompositionType>(para);  
+      tester.template test<DualDecompositionType>(para);  
    }
    {
       std::cout << "  *  SpanningTrees-Decomposition ... " << std::endl;
       typename DualDecompositionType::Parameter para;  
       para.decompositionId_= DualDecompositionType::Parameter::SPANNINGTREES;
-      tester.test<DualDecompositionType>(para);
+      tester.template test<DualDecompositionType>(para);
    } 
    return 0;
 }


### PR DESCRIPTION
Error message below:

```
/Users/nonadmin/local/tmp/opengm/src/unittest/inference/test_dualdecomposition.cxx:49:14: error: use 'template' keyword to treat 'test' as a dependent template name
      tester.test<DualDecompositionType>(para);  
             ^
             template 
/Users/nonadmin/local/tmp/opengm/src/unittest/inference/test_dualdecomposition.cxx:55:14: error: use 'template' keyword to treat 'test' as a dependent template name
      tester.test<DualDecompositionType>(para);
             ^
             template 
```
