### PR TITLE
Fixed a memory leak in qpbo.hxx

### DIFF
--- a/include/opengm/inference/external/qpbo.hxx
+++ b/include/opengm/inference/external/qpbo.hxx
@@ -147,6 +147,7 @@ namespace opengm {
       ::~QPBO() {
          delete label_;
          delete defaultLabel_;
+		 delete qpbo_;
       }
 
       template<class GM>
@@ -253,6 +254,7 @@ namespace opengm {
        
          visitor.end(*this);
          delete mapping;
+		 delete listUnlabel;
          return NORMAL;
       }
 


### PR DESCRIPTION
Hi,
I experienced an increasing RAM usage when using the QPBO inference engine of OpenGM. I found two pointers that were not deleted properly.
-Tobias
