### PR TITLE
Windows template parameters for std::max

### DIFF
--- a/include/opengm/unittests/blackboxtester.hxx
+++ b/include/opengm/unittests/blackboxtester.hxx
@@ -75,9 +75,9 @@ namespace opengm {
                      ValueType value = inf.value();
                      ValueType value2;
                      if(typeid(AccType) == typeid(opengm::Minimizer))
-                        value2 = value + std::min<ValueType>(1e20,std::max(1e-4,fabs(value)))*1e-6;
+                        value2 = value + std::min<ValueType>(1e20,std::max<ValueType>(1e-4,fabs(value)))*1e-6;
                      if(typeid(AccType) == typeid(opengm::Maximizer))
-                        value2 = value - std::min<ValueType>(1e20,std::max(1e-4,fabs(value)))*1e-6;
+                        value2 = value - std::min<ValueType>(1e20,std::max<ValueType>(1e-4,fabs(value)))*1e-6;
                    
                      std::cout << "value = " << value << "  ,  bound = " << bound << std::endl;
                      OPENGM_TEST(AccType::bop(bound,value2)|| bound==value2);


### PR DESCRIPTION
Added template parameter to std::max (i.e. std::max<ValueType>), which was already present for std::min.
This is required to compile under Windows.
