### PR TITLE
remove unnecessary variable "ts_" on mac from timer.hxx

### DIFF
--- a/include/opengm/utilities/timer.hxx
+++ b/include/opengm/utilities/timer.hxx
@@ -52,7 +52,9 @@ private:
    #endif
 
    TimerT start_;
+#if !defined(OPENGM_TIMER_MAC)
    TimerC ts_;
+#endif
    double duration_;
    double conversionFactor_;
    double elapsedTime_;


### PR DESCRIPTION
remove ts_ on mac
