### PR TITLE
python docs: Added CMake cache var toggle building of sphinx docs

### DIFF
--- a/src/interfaces/python/CMakeLists.txt
+++ b/src/interfaces/python/CMakeLists.txt
@@ -16,45 +16,48 @@ CONFIGURE_FILE(${CMAKE_CURRENT_SOURCE_DIR}/docsrc/source/conf.py.in ${CMAKE_CURR
 
 message(STATUS ${OPENGM_PYTHON_BUILD_MODULE_DIR})
 
-find_package(SPHINX)
-if(FALSE AND SPHINX_FOUND)
-    message(STATUS "FOUND_SPHINX")
+set( BUILD_PYTHON_DOCS 0 CACHE BOOL "Build the Python documentation with Sphinx" )
 
-    if(NOT DEFINED SPHINX_THEME)
-        set(SPHINX_THEME default)
+if(BUILD_PYTHON_DOCS)
+    find_package(SPHINX)
+    if(SPHINX_FOUND)
+        message(STATUS "FOUND_SPHINX")
+    
+        if(NOT DEFINED SPHINX_THEME)
+            set(SPHINX_THEME default)
+        endif()
+        if(NOT DEFINED SPHINX_THEME_DIR)
+            set(SPHINX_THEME_DIR)
+        endif()
+        # configured documentation tools and intermediate build results
+        set(BINARY_BUILD_DIR "${CMAKE_CURRENT_BINARY_DIR}/_build")
+        file(MAKE_DIRECTORY ${CMAKE_CURRENT_BINARY_DIR}/_build)
+        # Sphinx cache with pickled ReST documents
+        set(SPHINX_CACHE_DIR "${CMAKE_CURRENT_BINARY_DIR}/opengm/_doctrees")
+        # HTML output directory
+        set(SPHINX_HTML_DIR "${CMAKE_CURRENT_BINARY_DIR}/opengm/html")
+        configure_file(
+            "${CMAKE_CURRENT_SOURCE_DIR}/docsrc/source/conf.py.in"
+            #"${CMAKE_CURRENT_SOURCE_DIR}/docsrc/source/conf.py"
+            "${BINARY_BUILD_DIR}/conf.py"
+            @ONLY)
+        add_custom_target(python-doc ALL
+            ${SPHINX_EXECUTABLE}
+            -q -b html
+            #-c "${CMAKE_CURRENT_SOURCE_DIR}/docsrc/source"
+            -c "${BINARY_BUILD_DIR}"
+            -d "${SPHINX_CACHE_DIR}"
+            "${CMAKE_CURRENT_SOURCE_DIR}/docsrc/source"
+            "${SPHINX_HTML_DIR}"
+            COMMENT "Building HTML documentation with Sphinx")
+        add_dependencies(python-doc _opengmcore )
+        add_dependencies(python-doc _inference )
+        add_dependencies(python-doc _hdf5 )
+    
+    else()
+        message(STATUS "CANNOT Building HTML documentation with Sphinx , did not find Sphinx")
     endif()
-    if(NOT DEFINED SPHINX_THEME_DIR)
-        set(SPHINX_THEME_DIR)
-    endif()
-    # configured documentation tools and intermediate build results
-    set(BINARY_BUILD_DIR "${CMAKE_CURRENT_BINARY_DIR}/_build")
-    file(MAKE_DIRECTORY ${CMAKE_CURRENT_BINARY_DIR}/_build)
-    # Sphinx cache with pickled ReST documents
-    set(SPHINX_CACHE_DIR "${CMAKE_CURRENT_BINARY_DIR}/opengm/_doctrees")
-    # HTML output directory
-    set(SPHINX_HTML_DIR "${CMAKE_CURRENT_BINARY_DIR}/opengm/html")
-    configure_file(
-        "${CMAKE_CURRENT_SOURCE_DIR}/docsrc/source/conf.py.in"
-        #"${CMAKE_CURRENT_SOURCE_DIR}/docsrc/source/conf.py"
-        "${BINARY_BUILD_DIR}/conf.py"
-        @ONLY)
-    add_custom_target(python-doc ALL
-        ${SPHINX_EXECUTABLE}
-        -q -b html
-        #-c "${CMAKE_CURRENT_SOURCE_DIR}/docsrc/source"
-        -c "${BINARY_BUILD_DIR}"
-        -d "${SPHINX_CACHE_DIR}"
-        "${CMAKE_CURRENT_SOURCE_DIR}/docsrc/source"
-        "${SPHINX_HTML_DIR}"
-        COMMENT "Building HTML documentation with Sphinx")
-    add_dependencies(python-doc _opengmcore )
-    add_dependencies(python-doc _inference )
-    add_dependencies(python-doc _hdf5 )
-
-else()
-    message(STATUS "CANNOT Building HTML documentation with Sphinx , did not find Sphinx")
 endif()
-
 
 
 


### PR DESCRIPTION
An older rev of this file always tried to build the python docs if sphinx could be found on the system.  If you have more than one Python installation, it might find the wrong one, leading to errors.  A newer rev of this file simply disables the docs build unconditionally.  Instead, this PR controls the docs build with a cmake switch.
