### PR TITLE
remove ptrdiff_t workaround

### DIFF
--- a/include/opengm/datastructures/marray/marray.hxx
+++ b/include/opengm/datastructures/marray/marray.hxx
@@ -3,6 +3,7 @@
 #define MARRAY_HXX
 
 #include <cassert>
+#include <cstddef>
 #include <stdexcept> // runtime_error
 #include <limits>
 #include <string>
@@ -475,12 +476,7 @@ public:
     // STL random access iterator typedefs
     typedef typename std::random_access_iterator_tag iterator_category;
     typedef T value_type;
-    //gcc 4.6 bugfix
-    #if __GNUC__ == 4 && __GNUC_MINOR__ >= 6
     typedef std::ptrdiff_t difference_type;
-    #else
-    typedef ptrdiff_t difference_type;
-    #endif
     typedef typename marray_detail::IfBool<isConst, const T*, T*>::type pointer;
     typedef typename marray_detail::IfBool<isConst, const T&, T&>::type reference;
 

--- a/include/opengm/utilities/accessor_iterator.hxx
+++ b/include/opengm/utilities/accessor_iterator.hxx
@@ -2,6 +2,7 @@
 #ifndef OPENGM_ACCESSOR_ITERATOR
 #define OPENGM_ACCESSOR_ITERATOR
 
+#include <cstddef>
 #include <iterator>
 
 #include "opengm/opengm.hxx"
@@ -377,12 +378,7 @@ AccessorIterator<A, isConst>::operator-
    const AccessorIterator<A, isConstLocal>& it
 ) const
 {
-   //gcc 4.6 bugfix
-   #if __GNUC__ == 4 && __GNUC_MINOR__ >= 6
    typedef std::ptrdiff_t difference_type;
-   #else
-   typedef ptrdiff_t difference_type;
-   #endif
    OPENGM_ASSERT(this->accessor_ == it.accessor_);
    return static_cast<difference_type>(index_) - static_cast<difference_type>(it.index_);
 }

--- a/src/unittest/test_accessor_iterator.cxx
+++ b/src/unittest/test_accessor_iterator.cxx
@@ -1,3 +1,4 @@
+#include <cstddef>
 #include <vector>
 #include <iostream>
 
@@ -173,12 +174,7 @@ struct AccessorIteratorTest {
          Iterator it1(accessor);
          for(size_t j=0; j<accessor.size(); ++j) {
             Iterator it2(accessor, j);
-            //gcc 4.6 bugfix
-            #if __GNUC__ == 4 && __GNUC_MINOR__ >= 6
             typedef std::ptrdiff_t difference_type;
-            #else
-            typedef ptrdiff_t difference_type;
-            #endif
             OPENGM_TEST(it2 - it1 == j);
             OPENGM_TEST( int(it1 - it2) == int(-static_cast<difference_type>(j)));
          }


### PR DESCRIPTION
As per the standard, ptrdiff_t is available in namespace std when
including cstddef (also with gcc < 4.6).
See http://gcc.gnu.org/gcc-4.6/porting_to.html for why the previous
workaround was necessary.

This also enables building with other compilers, such as clang.