### PR TITLE
Fix typedef typo in view.hxx

### DIFF
--- a/include/opengm/functions/view.hxx
+++ b/include/opengm/functions/view.hxx
@@ -20,7 +20,7 @@ public:
    typedef typename GM::FactorType FactorType;
    typedef typename GM::OperatorType OperatorType;
    typedef typename GM::IndexType IndexType;
-   typedef typename GM::IndexType LabelType;
+   typedef typename GM::LabelType LabelType;
 
    ViewFunction();
    ViewFunction(const FactorType &);


### PR DESCRIPTION
The ViewFunction now passes through the LabelType of the underlying
GraphicalModel correctly.