### PR TITLE
Add utility class CanonicalView

### DIFF
--- a/include/opengm/functions/accumulated_view.hxx
+++ b/include/opengm/functions/accumulated_view.hxx
@@ -1,0 +1,158 @@
+//
+// File: accumulated_view.hxx
+//
+// This file is part of OpenGM.
+//
+// Copyright (C) 2015 Stefan Haller
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to
+// deal in the Software without restriction, including without limitation the
+// rights to use, copy, modify, merge, publish, distribute, sublicense, and/or
+// sell copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in
+// all copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING
+// FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS
+// IN THE SOFTWARE.
+//
+
+#pragma once
+#ifndef OPENGM_FUNCTIONS_ACCUMULATED_VIEW_HXX
+#define OPENGM_FUNCTIONS_ACCUMULATED_VIEW_HXX
+
+#include "opengm/functions/function_properties_base.hxx"
+
+namespace opengm {
+
+template<class GM>
+class AccumulatedViewFunction : public FunctionBase< AccumulatedViewFunction<GM>,
+                                                     typename GM::ValueType,
+                                                     typename GM::IndexType,
+                                                     typename GM::LabelType > {
+public:
+	typedef typename GM::IndexType IndexType;
+	typedef typename GM::IndexType LabelType;
+	typedef typename GM::ValueType ValueType;
+	typedef typename GM::FactorType FactorType;
+	typedef typename GM::OperatorType OperatorType;
+
+	AccumulatedViewFunction();
+	AccumulatedViewFunction(const FactorType &);
+	template<class ITERATOR> AccumulatedViewFunction(ITERATOR begin, ITERATOR end);
+
+	template<class ITERATOR> ValueType operator()(ITERATOR begin) const;
+	LabelType shape(const IndexType) const;
+	IndexType dimension() const;
+	IndexType size() const;
+
+private:
+	void check() const;
+
+	opengm::FastSequence<const FactorType*> factors_;
+};
+
+template<class GM>
+AccumulatedViewFunction<GM>::AccumulatedViewFunction()
+{
+}
+
+template<class GM>
+AccumulatedViewFunction<GM>::AccumulatedViewFunction
+(
+	const FactorType &factor
+)
+{
+	factors_.push_back(&factor);
+}
+
+template<class GM>
+template<class ITERATOR>
+AccumulatedViewFunction<GM>::AccumulatedViewFunction
+(
+	ITERATOR begin,
+	ITERATOR end
+)
+{
+	factors_.resize(end - begin);
+	std::copy(begin, end, factors_.begin());
+
+	check();
+}
+
+template<class GM>
+template<class Iterator>
+typename AccumulatedViewFunction<GM>::ValueType
+AccumulatedViewFunction<GM>::operator()
+(
+	Iterator begin
+) const
+{
+	check();
+
+	ValueType result = GM::OperatorType::template neutral<ValueType>();
+	for (size_t i = 0; i < factors_.size(); ++i)
+		GM::OperatorType::op(factors_[i]->operator()(begin), result);
+
+	return result;
+}
+
+template<class GM>
+typename AccumulatedViewFunction<GM>::LabelType
+AccumulatedViewFunction<GM>::shape
+(
+	const IndexType index
+) const
+{
+	check();
+	return factors_[0]->numberOfLabels(index);
+}
+
+template<class GM>
+typename AccumulatedViewFunction<GM>::IndexType
+AccumulatedViewFunction<GM>::dimension() const
+{
+	check();
+	return factors_[0]->numberOfVariables();
+}
+
+template<class GM>
+typename AccumulatedViewFunction<GM>::IndexType
+AccumulatedViewFunction<GM>::size() const
+{
+	check();
+	return factors_[0]->size();
+}
+
+template<class GM>
+void
+AccumulatedViewFunction<GM>::check() const
+{
+#ifndef NDEBUG
+	OPENGM_ASSERT_OP(factors_.size(), >, 0);
+
+	for (size_t i = 0; i < factors_.size(); ++i)
+		OPENGM_ASSERT(factors_[i] != NULL);
+
+	for (size_t i = 1; i < factors_.size(); ++i) {
+		OPENGM_ASSERT_OP(factors_[0]->size(), ==, factors_[i]->size());
+		OPENGM_ASSERT_OP(factors_[0]->numberOfVariables(), ==, factors_[i]->numberOfVariables());
+
+		for (IndexType j = 0; j < factors_[0]->numberOfVariables(); ++j) {
+			OPENGM_ASSERT_OP(factors_[0]->numberOfLabels(j), ==, factors_[i]->numberOfLabels(j));
+			OPENGM_ASSERT_OP(factors_[0]->variableIndex(j), ==, factors_[i]->variableIndex(j));
+		}
+	}
+#endif
+}
+
+} // namespace opengm
+
+#endif

--- a/include/opengm/utilities/canonical_view.hxx
+++ b/include/opengm/utilities/canonical_view.hxx
@@ -1,0 +1,138 @@
+//
+// File: canonical_view.hxx
+//
+// This file is part of OpenGM.
+//
+// Copyright (C) 2015 Stefan Haller
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to
+// deal in the Software without restriction, including without limitation the
+// rights to use, copy, modify, merge, publish, distribute, sublicense, and/or
+// sell copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in
+// all copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING
+// FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS
+// IN THE SOFTWARE.
+//
+
+#pragma once
+#ifndef OPENGM_UTILITIES_CANONICAL_FACTORS_HXX
+#define OPENGM_UTILITIES_CANONICAL_FACTORS_HXX
+
+#include <map>
+#include <vector>
+
+#include <opengm/functions/accumulated_view.hxx>
+#include <opengm/functions/constant.hxx>
+#include <opengm/graphicalmodel/graphicalmodel.hxx>
+#include <opengm/utilities/metaprogramming.hxx>
+
+
+namespace opengm {
+
+namespace canonical_view_internal {
+	// The type of the GraphicalModel is complicated, but can’t be typedef’d
+	// easilty. That’s why we use this handy type generator.
+	template<class GM>
+	struct Generator {
+		typedef GraphicalModel<
+			typename GM::ValueType,
+			typename GM::OperatorType,
+			typename meta::TypeListGenerator<
+				ConstantFunction<
+					typename GM::ValueType,
+					typename GM::IndexType,
+					typename GM::LabelType>,
+				AccumulatedViewFunction<GM> >::type,
+			typename GM::SpaceType
+		> Type;
+	};
+}
+
+
+/// \brief Canonical view of an arbitrary GraphicalModel
+///
+/// This class wraps an arbitrary GraphicalModel and acts as a view on the
+/// model. The original model is changed with respect to the following aspects:
+///
+///   - all variables are associated with exactly one unary factor (multiple
+///     unary factors get squashed into one, a non-existent unary factor is
+///     mapped to a zero-constant factor)
+///
+///   - there is at most one factor for a given set of variables (multiple
+///     factors attached to the clique are squashed into one factor)
+template<class GM>
+class CanonicalView : public canonical_view_internal::Generator<GM>::Type {
+public:
+	typedef typename canonical_view_internal::Generator<GM>::Type Parent;
+
+	using typename Parent::IndexType;
+	using typename Parent::LabelType;
+	using typename Parent::ValueType;
+
+	typedef ConstantFunction<ValueType, IndexType, LabelType> ConstFuncType;
+	typedef AccumulatedViewFunction<GM> ViewFuncType;
+
+	CanonicalView(const GM &gm)
+	: Parent(gm.space())
+	{
+		// FIXME: Use opengm::FastSequence, but operator< is missing. :-(
+		typedef std::vector<const typename GM::FactorType*> Factors;
+		typedef std::vector<Factors> UnaryFactors;
+		typedef std::map<std::vector<IndexType>, Factors> FactorMap;
+
+		UnaryFactors unaryFactors(gm.numberOfVariables());
+		FactorMap otherFactors;
+
+		// Append all unary factors to the corresponding unary factor vector.
+		// All other factors are inserted into the factor map. The keys are the
+		// variable indices of the factor, so we group factors of the same
+		// variables together.
+		for (IndexType i = 0; i < gm.numberOfFactors(); ++i) {
+			const typename GM::FactorType &f = gm[i];
+			if (f.numberOfVariables() == 1) {
+				unaryFactors[f.variableIndex(0)].push_back(&f);
+			} else {
+				std::vector<IndexType> vars(f.variableIndicesBegin(), f.variableIndicesEnd());
+				otherFactors[vars].push_back(&f);
+			}
+		}
+
+		// Associate each variable with *exactly* one unary factor. (Create
+		// an empty factor if missing.)
+		for (IndexType i = 0; i < gm.numberOfVariables(); ++i) {
+			typename Parent::FunctionIdentifier fid;
+			IndexType vars[1] = { i };
+
+			if (unaryFactors[i].empty()) {
+				LabelType shape[1] = { gm.numberOfLabels(i) };
+				ConstFuncType func(shape, shape+1, 0);
+				fid = this->addFunction(func);
+			} else {
+				ViewFuncType func(unaryFactors[i].begin(), unaryFactors[i].end());
+				fid = this->addFunction(func);
+			}
+
+			this->addFactor(fid, vars, vars+1);
+		}
+
+		// Accumulate all other factors (with order != 1).
+		for (typename FactorMap::const_iterator it = otherFactors.begin(); it != otherFactors.end(); ++it) {
+			ViewFuncType func(it->second.begin(), it->second.end());
+			this->addFactor(this->addFunction(func), it->first.begin(), it->first.end());
+		}
+	}
+};
+
+} // namespace opengm
+
+#endif


### PR DESCRIPTION
This class wraps an arbitrary GraphicalModel and acts as a view on the
model. The original model is changed with respect to the following
aspects:

  - all variables are associated with exactly one unary factor (multiple
    unary factors get squashed into one, a non-existent unary factor is
    mapped to a zero-constant factor)

  - there is at most one factor for a given set of variables (multiple
    factors attached to the clique are squashed into one factor)

Any comments are appreciated. :-)

I’m using this wrapper in combination with the partial optimality framework (the reduced model somehow contains overlapping unary factors).

Furthermore, some inference algorithms don’t work if there are no unary potentials (for example CombiLP).