### PR TITLE
Improvements for CanonicalView

### DIFF
--- a/include/opengm/functions/accumulated_view.hxx
+++ b/include/opengm/functions/accumulated_view.hxx
@@ -28,7 +28,8 @@
 #ifndef OPENGM_FUNCTIONS_ACCUMULATED_VIEW_HXX
 #define OPENGM_FUNCTIONS_ACCUMULATED_VIEW_HXX
 
-#include "opengm/functions/function_properties_base.hxx"
+#include <opengm/datastructures/fast_sequence.hxx>
+#include <opengm/functions/function_properties_base.hxx>
 
 namespace opengm {
 

--- a/include/opengm/functions/explicit_function.hxx
+++ b/include/opengm/functions/explicit_function.hxx
@@ -178,7 +178,7 @@ cloneAsExplicitFunction
    typedef ShapeWalker<typename FUNC::FunctionShapeIteratorType> Walker;
    out.resize(function.functionShapeBegin(), function.functionShapeEnd());
    Walker walker(function.functionShapeBegin(), function.dimension());
-   for (I i = 0; i < function.size(); ++i) {
+   for (I i = 0; i < function.size(); ++i, ++walker) {
       out(walker.coordinateTuple().begin()) =
          function(walker.coordinateTuple().begin());
    }

--- a/include/opengm/functions/explicit_function.hxx
+++ b/include/opengm/functions/explicit_function.hxx
@@ -155,6 +155,35 @@ void FunctionSerialization<ExplicitFunction<T, I, L> >::deserialize
    }
 }
 
+template<class FUNC, class T, class I, class L>
+ExplicitFunction<T, I, L>
+cloneAsExplicitFunction
+(
+   const FUNC &function
+)
+{
+   ExplicitFunction<T, I, L> result;
+   cloneAsExplicitFunction(function, result);
+   return result;
+}
+
+template<class FUNC, class T, class I, class L>
+void
+cloneAsExplicitFunction
+(
+   const FUNC &function,
+   ExplicitFunction<T, I, L> &out
+)
+{
+   typedef ShapeWalker<typename FUNC::FunctionShapeIteratorType> Walker;
+   out.resize(function.functionShapeBegin(), function.functionShapeEnd());
+   Walker walker(function.functionShapeBegin(), function.dimension());
+   for (I i = 0; i < function.size(); ++i) {
+      out(walker.coordinateTuple().begin()) =
+         function(walker.coordinateTuple().begin());
+   }
+}
+
 } // namespace opengm
 
 #endif // OPENGM_EXPLICIT_FUNCTION_HXX

--- a/include/opengm/utilities/canonical_view.hxx
+++ b/include/opengm/utilities/canonical_view.hxx
@@ -54,14 +54,13 @@ namespace canonical_view_internal {
 		// functions.
 		typedef ConstantFunction<ValType, IndType, LabType> ConstFunType;
 		typedef AccumulatedViewFunction<GM> AccViewType;
-		// FIXME: Remove duplicate types from type list!
 		typedef typename meta::TypeListGenerator<ConstFunType, AccViewType>::type NewTypeList;
 
 	public:
 		typedef GraphicalModel<
 			typename GM::ValueType,
 			typename GM::OperatorType,
-			typename meta::MergeTypeLists<OldTypeList, NewTypeList>::type,
+			typename meta::MergeTypeListsWithoutDups<OldTypeList, NewTypeList>::type,
 			typename GM::SpaceType
 		> type;
 	};

--- a/include/opengm/utilities/canonical_view.hxx
+++ b/include/opengm/utilities/canonical_view.hxx
@@ -33,6 +33,7 @@
 
 #include <opengm/functions/accumulated_view.hxx>
 #include <opengm/functions/constant.hxx>
+#include <opengm/functions/explicit_function.hxx>
 #include <opengm/graphicalmodel/graphicalmodel.hxx>
 #include <opengm/utilities/metaprogramming.hxx>
 

--- a/include/opengm/utilities/canonical_view.hxx
+++ b/include/opengm/utilities/canonical_view.hxx
@@ -39,7 +39,9 @@
 
 namespace opengm {
 
+/// \cond HIDDEN_SYMBOLS
 namespace canonical_view_internal {
+
 	// The type of the GraphicalModel is complicated, but can’t be typedef’d
 	// easilty. That’s why we use this handy type generator.
 	template<class GM>
@@ -134,8 +136,9 @@ namespace canonical_view_internal {
 		WRAPPER *gm_;
 		MapType map_;
 	};
-} // namespace canonical_view_internal
 
+} // namespace canonical_view_internal
+/// \endcond HIDDEN_SYMBOLS
 
 /// \brief Canonical view of an arbitrary GraphicalModel
 ///

--- a/include/opengm/utilities/canonical_view.hxx
+++ b/include/opengm/utilities/canonical_view.hxx
@@ -229,10 +229,10 @@ public:
 	typedef typename canonical_view_internal::Generator<GM>::type Parent;
 	typedef CanonicalView<GM, CLONE> MyType;
 
-	using typename Parent::IndexType;
-	using typename Parent::LabelType;
-	using typename Parent::ValueType;
-	using typename Parent::FunctionIdentifier;
+	typedef typename Parent::IndexType IndexType;
+	typedef typename Parent::LabelType LabelType;
+	typedef typename Parent::ValueType ValueType;
+	typedef typename Parent::FunctionIdentifier FunctionIdentifier;
 
 	typedef ExplicitFunction<ValueType, IndexType, LabelType> ExplFuncType;
 	typedef ConstantFunction<ValueType, IndexType, LabelType> ConstFuncType;

--- a/include/opengm/utilities/metaprogramming.hxx
+++ b/include/opengm/utilities/metaprogramming.hxx
@@ -728,6 +728,22 @@ namespace opengm {
             >::type
          >::type type;
       };
+      /// metaprogramming merge typelists without duplicates metafunctions
+      template<class TL, class OTHER_TL>
+      struct MergeTypeListsWithoutDups;
+      /// metaprogramming merge typelists without duplicates metafunctions
+      template<class TL, class THEAD, class TTAIL>
+      struct MergeTypeListsWithoutDups<TL, meta::TypeList<THEAD, TTAIL> > {
+         typedef typename MergeTypeListsWithoutDups<
+            typename meta::InsertInTypeListOrMoveToEnd<TL, THEAD>::type,
+            TTAIL
+         >::type type;
+      };
+      /// metaprogramming merge typelists without duplicates metafunctions
+      template<class TL>
+      struct MergeTypeListsWithoutDups<TL, meta::ListEnd> {
+         typedef TL type;
+      };
       /// metaprogramming has dublicates in typelist metafunction 
       template<class TL>
       struct HasDuplicatesInTypeList;

--- a/src/unittest/CMakeLists.txt
+++ b/src/unittest/CMakeLists.txt
@@ -115,5 +115,8 @@ if(BUILD_TESTING)
    add_executable(test-lp-functiontransfer test_lp_functiontransfer.cxx ${headers})
    add_test(test-lp-functiontransfer ${CMAKE_CURRENT_BINARY_DIR}/test-lp-functiontransfer)
    
+   add_executable(test-canonicalview test_canonicalview.cxx ${headers})
+   add_test(test-canonicalview ${CMAKE_CURRENT_BINARY_DIR}/test-canonicalview)
+
    add_subdirectory(inference)
 endif()

--- a/src/unittest/test_canonicalview.cxx
+++ b/src/unittest/test_canonicalview.cxx
@@ -1,0 +1,132 @@
+//
+// File: canonical_view.hxx
+//
+// This file is part of OpenGM.
+//
+// Copyright (C) 2015 Stefan Haller
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to
+// deal in the Software without restriction, including without limitation the
+// rights to use, copy, modify, merge, publish, distribute, sublicense, and/or
+// sell copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in
+// all copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING
+// FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS
+// IN THE SOFTWARE.
+//
+
+#include <cstdlib>
+
+#include <opengm/functions/explicit_function.hxx>
+#include <opengm/functions/potts.hxx>
+#include <opengm/graphicalmodel/graphicalmodel.hxx>
+#include <opengm/operations/adder.hxx>
+#include <opengm/utilities/canonical_view.hxx>
+#include <opengm/utilities/metaprogramming.hxx>
+
+#define ARRAY_LEN(x) (sizeof((x)) / sizeof((x)[0]))
+
+template<class T>
+void checkEqualityAndThrow(T a, T b)
+{
+	if (std::abs(a - b) > 0.00001)
+		throw std::runtime_error("Test failed!");
+}
+
+int main()
+{
+	typedef double ValueType;
+	typedef size_t IndexType;
+	typedef size_t LabelType;
+	typedef opengm::Adder OperatorType;
+	typedef opengm::DiscreteSpace<IndexType, LabelType> SpaceType;
+
+	typedef opengm::meta::TypeListGenerator<
+		opengm::ExplicitFunction<ValueType, IndexType, LabelType>,
+		opengm::PottsFunction<ValueType, IndexType, LabelType>
+	>::type FunctionTypes;
+
+	typedef opengm::GraphicalModel<ValueType, OperatorType, FunctionTypes, SpaceType> GraphicalModelType;
+
+	std::srand(time(0));
+
+	//
+	// Create GraphicalModel
+	//
+
+	LabelType spaceData[] = { 4, 4, 4, 4, 4, 4 };
+	SpaceType space(spaceData, spaceData + ARRAY_LEN(spaceData));
+	GraphicalModelType gm(space);
+
+	//
+	// Insert random unary factors multiple times.
+	//
+
+	for (IndexType i = 0; i < gm.numberOfVariables(); ++i) {
+		IndexType varData[] = { i };
+		LabelType shapeData[] = { gm.numberOfLabels(i) };
+		opengm::ExplicitFunction<ValueType, IndexType, LabelType> f(shapeData, shapeData + ARRAY_LEN(shapeData));
+
+		for (LabelType j = 0; j < gm.numberOfLabels(i); ++j)
+			f(j) = static_cast<ValueType>(std::rand()) / RAND_MAX;
+
+		GraphicalModelType::FunctionIdentifier fid = gm.addFunction(f);
+
+		for (size_t i = 0; i < 4; ++i)
+			gm.addFactor(fid, varData, varData + ARRAY_LEN(varData));
+	}
+
+	//
+	// Insert Potts pairwise factors multiple times
+	//
+
+	opengm::PottsFunction<ValueType, IndexType, LabelType> potts(spaceData[0], spaceData[0], 0, 1);
+	GraphicalModelType::FunctionIdentifier pottsFid = gm.addFunction(potts);
+
+	for (IndexType i = 1; i < gm.numberOfVariables(); ++i) {
+		IndexType varData[] = { i-1, i };
+
+		for (size_t i = 0; i < 4; ++i)
+			gm.addFactor(pottsFid, varData, varData + ARRAY_LEN(varData));
+	}
+
+	//
+	// Generate all different kinds of CanonicalViews
+	//
+
+	opengm::CanonicalView<GraphicalModelType, opengm::canonical_view::CloneNever> view1(gm);
+	opengm::CanonicalView<GraphicalModelType, opengm::canonical_view::CloneViews> view2(gm);
+	opengm::CanonicalView<GraphicalModelType, opengm::canonical_view::CloneDeep> view3(gm);
+
+	//
+	// Test all possible combinations of labels
+	//
+
+	IndexType size = 1;
+	for (size_t i = 0; i < ARRAY_LEN(spaceData); ++i)
+		size *= spaceData[i];
+
+	opengm::ShapeWalker<LabelType*> walker(spaceData, ARRAY_LEN(spaceData));
+
+	for (IndexType i = 0; i < size; ++i, ++walker) {
+		ValueType valRef = gm.evaluate(walker.coordinateTuple().begin());
+		ValueType valView1 = view1.evaluate(walker.coordinateTuple().begin());
+		ValueType valView2 = view2.evaluate(walker.coordinateTuple().begin());
+		ValueType valView3 = view3.evaluate(walker.coordinateTuple().begin());
+
+		checkEqualityAndThrow(valRef, valView1);
+		checkEqualityAndThrow(valRef, valView2);
+		checkEqualityAndThrow(valRef, valView3);
+	}
+
+	return 0;
+}


### PR DESCRIPTION
This pull request is a follow-up to #361.

  - Avoids view functions whenever possible.
  - Reuses original factor functions whenever possible.
  - Template parameter determines if factors should be cloned as ExplicitFunctions.

Additionally, the branch now includes a unit test (checks that all labelings evaluate to the correct energy).