### PR TITLE
Fix wrong brackets

### DIFF
--- a/include/opengm/utilities/accumulation.hxx
+++ b/include/opengm/utilities/accumulation.hxx
@@ -92,7 +92,7 @@ Accumulation<Value, State, Accumulator>::state
    size_t index
 ) const
 {
-   return state_(index);
+   return state_[index];
 }
    
 template<class Value, class State, class Accumulator>


### PR DESCRIPTION
opengm::FastSequence does not have operator (). It looks like simple typo, since it has operator [].

This function is template function and it seems that nobody use it, thus gcc does not throw error, but nvcc compiler does.