### PR TITLE
FIX for out-of-bounds array access.

### DIFF
--- a/include/opengm/inference/astar.hxx
+++ b/include/opengm/inference/astar.hxx
@@ -408,7 +408,7 @@ namespace opengm {
          }
          std::vector<size_t> conf(numNodes_);
          a.conf.resize(subconfsize+1);
-         for(size_t i=0; i<numStates_[subconfsize]; ++i) {
+         for(size_t i=0; i<numStates_[parameter_.nodeOrder_[subconfsize]]; ++i) {
             a.conf[subconfsize] = i;
             bp.constrainedOptimum(parameter_.nodeOrder_,a.conf,conf);
             a.value   = tgm.evaluate(conf);


### PR DESCRIPTION
My colleague spotted this.

The bug can result in out-of-bound array accesses and potentially strange inference results (non-optimal solutions, negative energies for strictly positive problems, crashes).

He also has a small test test program that would show the bug - I'll ask him to provide it.
