### PR TITLE
Fix/python module install path

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -692,7 +692,8 @@ if(BUILD_PYTHON_WRAPPER)
    #find_path(PYTHON_MODULE_INSTALL )   
    install(DIRECTORY "${CMAKE_CURRENT_BINARY_DIR}/src/interfaces/python/opengm"
    DESTINATION "lib/python${PYTHON_VERSION_MAJOR}.${PYTHON_VERSION_MINOR}/site-packages"
-   PATTERN ".py" 
+   PATTERN ".py"
+   PATTERN ".so"
    PATTERN ".git"  EXCLUDE 
    PATTERN  ".txt" EXCLUDE
    PATTERN  ".hxx" EXCLUDE )

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -690,7 +690,8 @@ if(BUILD_PYTHON_WRAPPER)
    ) 
 
    #find_path(PYTHON_MODULE_INSTALL )   
-   install(DIRECTORY "${CMAKE_CURRENT_BINARY_DIR}/src/interfaces/python/opengm" DESTINATION "${OPENGM_PYTHON_MODULE_INSTALL_DIR}" 
+   install(DIRECTORY "${CMAKE_CURRENT_BINARY_DIR}/src/interfaces/python/opengm"
+   DESTINATION "lib/python${PYTHON_VERSION_MAJOR}.${PYTHON_VERSION_MINOR}/site-packages"
    PATTERN ".py" 
    PATTERN ".git"  EXCLUDE 
    PATTERN  ".txt" EXCLUDE

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -646,7 +646,7 @@ install(DIRECTORY "${CMAKE_CURRENT_SOURCE_DIR}/include/opengm" DESTINATION inclu
 #--------------------------------------------------------------
 if(BUILD_PYTHON_WRAPPER)
    #find python
-   FIND_PACKAGE(PythonInterp)
+   FIND_PACKAGE(PythonInterp REQUIRED)
    #find nose
    execute_process(COMMAND ${PYTHON_EXECUTABLE} -c "import nose"  RESULT_VARIABLE PYTHON_NOSETESTS_NOT_FOUND)
    # find numpy


### PR DESCRIPTION
This PR makes the installation of the Python modules less fragile to the choice of installation paths. Before, the "site-package" location was queried from the interpreter, which is not optimal for 2 reasons:

- It is not compatible with custom install locations set via ${CMAKE_INSTALL_PREFIX},
- The site-package location can depend on the type of Python installation, see [1]. On Debian for instance, the resulting module gets installed under `dist-packages` instead of `site-packages`, which is not recommended.

[1] https://wiki.debian.org/Python

With this PR, the Python interface gets installed under `${CMAKE_INSTALL_PREFIX}/lib/pythonX.Y/site-packages`, whereby (X, Y) are obtained from the interpreter find module. I also took the liberty to make the interpreter a requirement if BUILD_PYTHON_WRAPPER is set, and add the extension modules to the list of installed files.

That being said, the current installation rules aren't ideal, since a lot more stuff than expected gets installed under `${CMAKE_INSTALL_PREFIX}/lib/pythonX.Y/site-packages/opengm`. This should be addressed in a separate PR.