### PR TITLE
s/undefine/undef in macro checks

### DIFF
--- a/src/unittest/inference/test_graphcut.cxx
+++ b/src/unittest/inference/test_graphcut.cxx
@@ -21,7 +21,7 @@
 #  else
 #    define NDEBUG //Hot-fix to deal with floating point assert problem in boost
 #    include <opengm/inference/auxiliary/minstcutboost.hxx>
-#    undefine NDEBUG
+#    undef NDEBUG
 #  endif
 #endif
 #ifdef WITH_MAXFLOW


### PR DESCRIPTION
Fixes a typo in graphcut test suite (#undefine -> #undef).