### PR TITLE
Fix/python doc installation

### DIFF
--- a/src/interfaces/python/CMakeLists.txt
+++ b/src/interfaces/python/CMakeLists.txt
@@ -19,10 +19,8 @@ message(STATUS ${OPENGM_PYTHON_BUILD_MODULE_DIR})
 set( BUILD_PYTHON_DOCS 0 CACHE BOOL "Build the Python documentation with Sphinx" )
 
 if(BUILD_PYTHON_DOCS)
-    find_package(SPHINX)
-    if(SPHINX_FOUND)
-        message(STATUS "FOUND_SPHINX")
-    
+    find_package(SPHINX REQUIRED)
+
         if(NOT DEFINED SPHINX_THEME)
             set(SPHINX_THEME default)
         endif()
@@ -50,10 +48,6 @@ if(BUILD_PYTHON_DOCS)
         add_dependencies(python-doc _opengmcore )
         add_dependencies(python-doc _inference )
         add_dependencies(python-doc _hdf5 )
-    
-    else()
-        message(STATUS "CANNOT Building HTML documentation with Sphinx , did not find Sphinx")
-    endif()
 endif()
 
 

--- a/src/interfaces/python/CMakeLists.txt
+++ b/src/interfaces/python/CMakeLists.txt
@@ -30,22 +30,19 @@ if(BUILD_PYTHON_DOCS)
             set(SPHINX_THEME_DIR)
         endif()
         # configured documentation tools and intermediate build results
-        set(BINARY_BUILD_DIR "${CMAKE_CURRENT_BINARY_DIR}/_build")
-        file(MAKE_DIRECTORY ${CMAKE_CURRENT_BINARY_DIR}/_build)
+        set(SPHINX_BUILD_DIR "${CMAKE_CURRENT_BINARY_DIR}/doc/_build")
         # Sphinx cache with pickled ReST documents
-        set(SPHINX_CACHE_DIR "${CMAKE_CURRENT_BINARY_DIR}/opengm/_doctrees")
+        set(SPHINX_CACHE_DIR "${CMAKE_CURRENT_BINARY_DIR}/doc/_doctrees")
         # HTML output directory
-        set(SPHINX_HTML_DIR "${CMAKE_CURRENT_BINARY_DIR}/opengm/html")
+        set(SPHINX_HTML_DIR "${CMAKE_CURRENT_BINARY_DIR}/doc/html")
         configure_file(
             "${CMAKE_CURRENT_SOURCE_DIR}/docsrc/source/conf.py.in"
-            #"${CMAKE_CURRENT_SOURCE_DIR}/docsrc/source/conf.py"
-            "${BINARY_BUILD_DIR}/conf.py"
+            "${SPHINX_BUILD_DIR}/conf.py"
             @ONLY)
         add_custom_target(python-doc ALL
             ${SPHINX_EXECUTABLE}
             -q -b html
-            #-c "${CMAKE_CURRENT_SOURCE_DIR}/docsrc/source"
-            -c "${BINARY_BUILD_DIR}"
+            -c "${SPHINX_BUILD_DIR}"
             -d "${SPHINX_CACHE_DIR}"
             "${CMAKE_CURRENT_SOURCE_DIR}/docsrc/source"
             "${SPHINX_HTML_DIR}"

--- a/src/interfaces/python/CMakeLists.txt
+++ b/src/interfaces/python/CMakeLists.txt
@@ -40,6 +40,9 @@ if(BUILD_PYTHON_DOCS)
             "${CMAKE_CURRENT_SOURCE_DIR}/docsrc/source"
             "${SPHINX_HTML_DIR}"
             COMMENT "Building HTML documentation with Sphinx")
+        install(DIRECTORY ${SPHINX_HTML_DIR}
+            DESTINATION share/doc/python-opengm
+        )
         add_dependencies(python-doc _opengmcore )
         add_dependencies(python-doc _inference )
         add_dependencies(python-doc _hdf5 )

--- a/src/interfaces/python/CMakeLists.txt
+++ b/src/interfaces/python/CMakeLists.txt
@@ -11,7 +11,7 @@ else()
    file(COPY ${CMAKE_CURRENT_SOURCE_DIR}/examples/ DESTINATION ${CMAKE_CURRENT_BINARY_DIR}/examples )
 endif()
 
-set( BUILD_PYTHON_DOCS 0 CACHE BOOL "Build the Python documentation with Sphinx" )
+option(BUILD_PYTHON_DOCS "Build the Python documentation with Sphinx" OFF)
 
 if(BUILD_PYTHON_DOCS)
     find_package(SPHINX REQUIRED)

--- a/src/interfaces/python/CMakeLists.txt
+++ b/src/interfaces/python/CMakeLists.txt
@@ -11,11 +11,6 @@ else()
    file(COPY ${CMAKE_CURRENT_SOURCE_DIR}/examples/ DESTINATION ${CMAKE_CURRENT_BINARY_DIR}/examples )
 endif()
 
-SET(OPENGM_PYTHON_BUILD_MODULE_DIR ${CMAKE_CURRENT_BINARY_DIR})
-CONFIGURE_FILE(${CMAKE_CURRENT_SOURCE_DIR}/docsrc/source/conf.py.in ${CMAKE_CURRENT_SOURCE_DIR}/docsrc/source/conf.py  @ONLY)
-
-message(STATUS ${OPENGM_PYTHON_BUILD_MODULE_DIR})
-
 set( BUILD_PYTHON_DOCS 0 CACHE BOOL "Build the Python documentation with Sphinx" )
 
 if(BUILD_PYTHON_DOCS)


### PR DESCRIPTION
This PR provides a cleaner installation target for the Python docs. BUILD_PYTHON_DOCS is made a CMake option and, if enabled, Sphinx becomes a requirement. Sphinxdoc artefacts (build, cache and html dirs) are separated from the Python wrapper binary directory to avoid installation conflicts. Finally, the docs gets installed under the recommended share/doc/python-opengm path.

This PR has been tested on my Linux machine, and the installed Python docs render as expected. The installed directory is also free from CMake or git clutter.