### PR TITLE
Use more selective install target for public OpenGM headers

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -639,7 +639,10 @@ endif()
 #--------------------------------------------------------------
 # install
 #--------------------------------------------------------------
-install(DIRECTORY "${CMAKE_CURRENT_SOURCE_DIR}/include/opengm" DESTINATION include PATTERN ".hxx" PATTERN ".git" EXCLUDE)
+install(DIRECTORY "${CMAKE_CURRENT_SOURCE_DIR}/include/opengm"
+  DESTINATION include
+  FILES_MATCHING PATTERN "*.hxx"
+)
 
 #--------------------------------------------------------------
 # test and install opengm python


### PR DESCRIPTION
The proposed install target is more selective and only installs the public headers. The previous target was also installing some undesired files, such as an additional LICENSE.txt and a config.hxx.cmake.