### PR TITLE
Add missing "*.hpp" pattern to the OpenGM headers install target

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -641,7 +641,9 @@ endif()
 #--------------------------------------------------------------
 install(DIRECTORY "${CMAKE_CURRENT_SOURCE_DIR}/include/opengm"
   DESTINATION include
-  FILES_MATCHING PATTERN "*.hxx"
+  FILES_MATCHING
+  PATTERN "*.hxx"
+  PATTERN "*.hpp"
 )
 
 #--------------------------------------------------------------


### PR DESCRIPTION
Otherwise opengm/inference/fix-fusion* files are not installed.