### PR TITLE
Make documentation build reproducible

### DIFF
--- a/Doxyfile.in
+++ b/Doxyfile.in
@@ -899,7 +899,7 @@ HTML_COLORSTYLE_GAMMA  = 80
 # page will contain the date and time when the page was generated. Setting 
 # this to NO can help when comparing the output of multiple runs.
 
-HTML_TIMESTAMP         = YES
+HTML_TIMESTAMP         = NO
 
 # If the HTML_ALIGN_MEMBERS tag is set to YES, the members of classes, 
 # files or namespaces will be aligned in HTML using tables. If set to 


### PR DESCRIPTION
Unless you have a need for HTML time stamps in the generated documentation, may I suggest this PR for turning them off. They hurt the reproducibility of the build process.