### PR TITLE
Fixed __repr__ function

### DIFF
--- a/src/interfaces/python/opengm/opengmcore/function_injector.py
+++ b/src/interfaces/python/opengm/opengmcore/function_injector.py
@@ -89,7 +89,7 @@ def _extend_function_type_classes():
             return numpy.array(self).__str__()
         def __repr__(self):
             " get a function representation as s string "
-            return self.asNumpyArray().__repr__()
+            return numpy.array(self).__repr__()
 
         def __getitem__(self,labels):
           """ get the values of a function for a given labeling


### PR DESCRIPTION
I originally wrote this up as a bug report, but the issue seemed simple enough that I just fixed it. 
Here is the original bug description: 

Following the tutorial in https://github.com/opengm/opengm/blob/master/src/interfaces/python/examples/tutorial/Irregular%20Factor%20Graphs.ipynb

I'm coming across an error in the python bindings for the pottsFunction if the __repr__ method is called. 

```python
>>> regularizer = opengm.pottsFunction([nCluster]*2,0.0,beta)
>>> # str works
>>> print(str(regularizer))
[[  0.  40.  40.  40.  40.]
 [ 40.   0.  40.  40.  40.]
 [ 40.  40.   0.  40.  40.]
 [ 40.  40.  40.   0.  40.]
 [ 40.  40.  40.  40.   0.]]
>>> # repr fails
>>> print(repr(regularizer))
~/venv/local/lib/python2.7/site-packages/opengm/opengmcore/function_injector.pyc in __repr__(self)
     90         def __repr__(self):
     91             " get a function representation as s string "
---> 92             return self.asNumpyArray().__repr__()
     93 
     94         def __getitem__(self,labels):

AttributeError: 'PottsFunction' object has no attribute 'asNumpyArray'
```

However, if the __str__ method is called everything is ok. 

The definition of __str__ is 

        def __str__(self):
            " get a function as string "
            return numpy.array(self).__str__()

whereas repr looks like 

        def __repr__(self):
            " get a function representation as s string "
            return self.asNumpyArray().__repr__()

It looks like the __repr__ function should simply be changed to the structure of the __str__ function. 
This error also happens for opengm.PottsGFunction. I haven't tried it for anything else, but I assume it occurs in other places if a wrapper is creating this. 
