### PR TITLE
cmake: Don't use add_library(... MODULE ...)

### DIFF
--- a/src/interfaces/python/opengm/hdf5/CMakeLists.txt
+++ b/src/interfaces/python/opengm/hdf5/CMakeLists.txt
@@ -32,17 +32,10 @@ include_directories(
 #--------------------------------------------------------------
 # Add opengmcore library
 #--------------------------------------------------------------
-if(APPLE)
-    add_library(_hdf5 MODULE 
-    hdf5.cpp
-    pyHdf5.cxx
-    )
-else()
-    add_library(_hdf5 SHARED  
-    hdf5.cpp
-    pyHdf5.cxx
-    )
-endif(APPLE)
+add_library(_hdf5 SHARED  
+hdf5.cpp
+pyHdf5.cxx
+)
 
 
 

--- a/src/interfaces/python/opengm/inference/CMakeLists.txt
+++ b/src/interfaces/python/opengm/inference/CMakeLists.txt
@@ -58,11 +58,7 @@ set(INF_TARGETS
 #--------------------------------------------------------------
 # Add opengmcore library
 #--------------------------------------------------------------
-if(APPLE)
-    add_library(_inference MODULE ${INF_TARGETS})
-else()
-    add_library(_inference SHARED  ${INF_TARGETS})
-endif(APPLE)
+add_library(_inference SHARED  ${INF_TARGETS})
 
 #--------------------------------------------------------------
 # Definitions

--- a/src/interfaces/python/opengm/opengmcore/CMakeLists.txt
+++ b/src/interfaces/python/opengm/opengmcore/CMakeLists.txt
@@ -31,39 +31,21 @@ include_directories(
 #--------------------------------------------------------------
 # Add opengmcore library
 #--------------------------------------------------------------
-if(APPLE)
-    add_library(_opengmcore MODULE 
-    opengmcore.cpp
-    pyGmManipulator.cxx
-    pyConfig.cxx
-    pyGm.cxx
-    pyFactor.cxx
-    pyMovemaker.cxx
-    pyIfactor.cxx
-    pyFid.cxx
-    pyFunctionTypes.cxx
-    pyFunctionGen.cxx
-    pySpace.cxx
-    pyVector.cxx
-    pyEnum.cxx
-    )
-else()
-    add_library(_opengmcore SHARED  
-    opengmcore.cpp
-    pyGmManipulator.cxx
-    pyConfig.cxx
-    pyGm.cxx
-    pyFactor.cxx
-    pyMovemaker.cxx
-    pyIfactor.cxx
-    pyFid.cxx
-    pyFunctionTypes.cxx
-    pyFunctionGen.cxx
-    pySpace.cxx
-    pyVector.cxx
-    pyEnum.cxx
-    )
-endif(APPLE)
+add_library(_opengmcore SHARED  
+opengmcore.cpp
+pyGmManipulator.cxx
+pyConfig.cxx
+pyGm.cxx
+pyFactor.cxx
+pyMovemaker.cxx
+pyIfactor.cxx
+pyFid.cxx
+pyFunctionTypes.cxx
+pyFunctionGen.cxx
+pySpace.cxx
+pyVector.cxx
+pyEnum.cxx
+)
 
 
 


### PR DESCRIPTION
I recently noticed that the opengm python binding build scripts use `add_library(... MODULE ...)` in some places instead of `add_library(... SHARED ...)`.  I hadn't seen this before, so I looked it up:
http://stackoverflow.com/questions/4845984/difference-between-modules-and-shared-libraries

The python bindings seem to work just fine on mac when using the standard `SHARED` mode instead of `MODULE`.  Is there a reason to use `MODULE`?  If not, here's a PR to simplify the build scripts a little bit.