### PR TITLE
Have cmake link python libraries

### DIFF
--- a/src/interfaces/python/opengm/hdf5/CMakeLists.txt
+++ b/src/interfaces/python/opengm/hdf5/CMakeLists.txt
@@ -54,7 +54,7 @@ endif(APPLE)
 if(MSVC AND NOT(MSVC_VERSION LESS 1400))
     SET_TARGET_PROPERTIES(_hdf5 PROPERTIES COMPILE_FLAGS "/bigobj")
 endif()
-target_link_libraries(_hdf5 ${Boost_PYTHON_LIBRARIES}  ${HDF5_LIBRARIES})
+target_link_libraries(_hdf5 ${Boost_PYTHON_LIBRARIES} ${HDF5_LIBRARIES} ${PYTHON_LIBRARIES})
 set_target_properties(_hdf5 PROPERTIES PREFIX "")
 
 

--- a/src/interfaces/python/opengm/inference/CMakeLists.txt
+++ b/src/interfaces/python/opengm/inference/CMakeLists.txt
@@ -77,13 +77,12 @@ if(MSVC AND NOT(MSVC_VERSION LESS 1400))
     SET_TARGET_PROPERTIES(_inference PROPERTIES COMPILE_FLAGS "/bigobj")
 endif()
 
+target_link_libraries(_inference ${Boost_PYTHON_LIBRARIES} ${PYTHON_LIBRARIES})
 
 if(LINK_RT)
     find_library(RT rt)
-    target_link_libraries(_inference ${Boost_PYTHON_LIBRARIES} rt)
-else()
-    target_link_libraries(_inference ${Boost_PYTHON_LIBRARIES})
-endif(LINK_RT)
+    target_link_libraries(_inference rt)
+endif()
 
 set_target_properties(_inference PROPERTIES PREFIX "")
 

--- a/src/interfaces/python/opengm/opengmcore/CMakeLists.txt
+++ b/src/interfaces/python/opengm/opengmcore/CMakeLists.txt
@@ -75,20 +75,18 @@ if(MSVC AND NOT(MSVC_VERSION LESS 1400))
     SET_TARGET_PROPERTIES(_opengmcore PROPERTIES COMPILE_FLAGS "/bigobj")
 endif()
 
-
+target_link_libraries(_opengmcore ${Boost_PYTHON_LIBRARIES} ${PYTHON_LIBRARIES})
 
 if(LINK_RT)
     find_library(RT rt)
-    target_link_libraries(_opengmcore ${Boost_PYTHON_LIBRARIES} rt)
-else()
-    target_link_libraries(_opengmcore ${Boost_PYTHON_LIBRARIES})
-endif(LINK_RT)
+    target_link_libraries(_opengmcore rt)
+endif()
 
 IF(WITH_MAXFLOW)
    #target_link_libraries(_opengmcore  external-library-maxflow)
 endif(WITH_MAXFLOW)
 if(WITH_HDF5)
-   target_link_libraries(_opengmcore  ${HDF5_CORE_LIBRARY} ${HDF5_LIBRARIES} )
+   target_link_libraries(_opengmcore  ${HDF5_CORE_LIBRARY} ${HDF5_LIBRARIES})
 endif()
 
 


### PR DESCRIPTION
When linking in Xcode 7.2.1, I was getting undefined symbols for  `_Py_Initialize`, etc. Having cmake link to the python library via `target_link_libraries(_hdf5 ${PYTHON_LIBRARIES})` seemed to fix this for me. I'm a cmake novice, so please review.

I configured my project for Xcode with:
    cmake -DWITH_BOOST=ON -DBUILD_COMMANDLINE=ON -DBUILD_EXAMPLES=ON -DBUILD_TUTORIALS=ON -DBUILD_PYTHON_WRAPPER=ON -DWITH_HDF5=ON -G Xcode ..
