### PR TITLE
Add install support for external targets (headers+libs, QPBO)

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -96,7 +96,7 @@ OPTION(BUILD_MATLAB_WRAPPER "Build matlab wrapper" OFF)
 ###Grante needs C++11. Since we have not tested OpenGM under this standard yet, using Grante is realy experimental!!!
 ###OPTION(WITH_GRANTE "Include wrapper for grante" OFF)
 OPTION(WITH_MEMINFO "Use memory logging in visitor" OFF)
-
+OPTION(INSTALL_EXTERNAL_LIB "Install library to link all external sources enabled via 'WITH...' CMake options" OFF)
 
 #--------------------------------------------------------------
 # MEMINFO

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -21,8 +21,9 @@ set (OPENGM_VERSION_PATCH 1)
 #--------------------------------------------------------------
 # global headers
 #--------------------------------------------------------------
-file(GLOB_RECURSE headers include/*.hxx)
-include_directories(include)
+file(GLOB_RECURSE headers "${CMAKE_SOURCE_DIR}/include/*.hxx")
+include_directories(${CMAKE_SOURCE_DIR}/include)
+include_directories(${CMAKE_BINARY_DIR}/include)
 
 #--------------------------------------------------------------
 # debug info
@@ -275,7 +276,6 @@ if(WITH_QPBO)
    message(STATUS "build with external inference algorithm QPBO")
    SET(QPBO_PATCHEDSRCDIR "${PROJECT_SOURCE_DIR}/src/external/QPBO-v1.3.src-patched" CACHE STRING "QPBO patched source code directory")
    add_definitions(-DWITH_QPBO)
-   include_directories(${QPBO_PATCHEDSRCDIR})
 else()
    message(STATUS "build without external inference algorithm QPBO")
 endif(WITH_QPBO)
@@ -647,7 +647,14 @@ endif()
 #--------------------------------------------------------------
 # install
 #--------------------------------------------------------------
-install(DIRECTORY "${CMAKE_CURRENT_SOURCE_DIR}/include/opengm"
+install(DIRECTORY "${CMAKE_SOURCE_DIR}/include/opengm"
+  DESTINATION include
+  FILES_MATCHING
+  PATTERN "*.hxx"
+  PATTERN "*.hpp"
+  PATTERN "*.h"
+)
+install(DIRECTORY "${CMAKE_BINARY_DIR}/include/opengm"
   DESTINATION include
   FILES_MATCHING
   PATTERN "*.hxx"

--- a/include/opengm/inference/alphaexpansionfusion.hxx
+++ b/include/opengm/inference/alphaexpansionfusion.hxx
@@ -5,7 +5,7 @@
 #include "opengm/inference/inference.hxx"
 #include "opengm/inference/visitors/visitors.hxx"
 #include "opengm/inference/fix-fusion/fusion-move.hpp"
-#include "QPBO.h"
+#include "opengm/inference/external/qpbo/QPBO.h"
 
 namespace opengm {
 

--- a/include/opengm/inference/auxiliary/fusion_move/fusion_mover.hxx
+++ b/include/opengm/inference/auxiliary/fusion_move/fusion_mover.hxx
@@ -21,7 +21,7 @@
 #include "opengm/inference/lpcplex.hxx"
 #endif
 #ifdef WITH_QPBO
-#include "QPBO.h"
+#include "opengm/inference/external/qpbo/QPBO.h"
 #include "opengm/inference/reducedinference.hxx"
 #include "opengm/inference/hqpbo.hxx"
 #endif

--- a/include/opengm/inference/cgc/submodel2.hxx
+++ b/include/opengm/inference/cgc/submodel2.hxx
@@ -10,7 +10,7 @@
 #include <opengm/inference/multicut.hxx>
 #endif
 #ifdef WITH_QPBO
-#include "QPBO.h"
+#include <opengm/inference/external/qpbo/QPBO.h>
 #endif
 
 #if defined(WITH_BLOSSOM5) && defined(WITH_PLANARITY)

--- a/include/opengm/inference/external/qpbo.hxx
+++ b/include/opengm/inference/external/qpbo.hxx
@@ -7,8 +7,7 @@
 #include "opengm/inference/visitors/visitors.hxx"
 //#include "opengm/inference/alphabetaswap.hxx"
 //#include "opengm/inference/alphaexpansion.hxx"
-
-#include "QPBO.h"
+#include "opengm/inference/external/qpbo/QPBO.h"
 
 namespace opengm {
    namespace external {

--- a/include/opengm/inference/fix-fusion/fusion-move.hpp
+++ b/include/opengm/inference/fix-fusion/fusion-move.hpp
@@ -9,7 +9,7 @@
 
 #define NO_QPBO
 #ifndef NO_QPBO
-#include "QPBO.h"
+#include "opengm/inference/external/qpbo/QPBO.h"
 #endif
 
 /*

--- a/include/opengm/inference/fusion_based_inf.hxx
+++ b/include/opengm/inference/fusion_based_inf.hxx
@@ -21,7 +21,7 @@
 #include "opengm/inference/lpcplex.hxx"
 #endif
 #ifdef WITH_QPBO
-#include "QPBO.h"
+#include "opengm/inference/external/qpbo/QPBO.h"
 #include "opengm/inference/hqpbo.hxx"
 #include "opengm/inference/reducedinference.hxx"
 #endif

--- a/include/opengm/inference/intersection_based_inf.hxx
+++ b/include/opengm/inference/intersection_based_inf.hxx
@@ -24,7 +24,7 @@
 #endif
 
 #ifdef WITH_QPBO
-#include <QPBO.h>
+#include "opengm/inference/external/qpbo/QPBO.h"
 #endif
 
 #include <stdlib.h>     /* srand, rand */

--- a/include/opengm/inference/self_fusion.hxx
+++ b/include/opengm/inference/self_fusion.hxx
@@ -20,7 +20,7 @@
 #include "opengm/inference/lpcplex.hxx"
 #endif
 #ifdef WITH_QPBO
-#include "QPBO.h"
+#include "opengm/inference/external/qpbo/QPBO.h"
 #include "opengm/inference/reducedinference.hxx"
 #include "opengm/inference/hqpbo.hxx"
 #endif

--- a/src/external/CMakeLists.txt
+++ b/src/external/CMakeLists.txt
@@ -1,5 +1,9 @@
 add_subdirectory(patches)
 
+IF(INSTALL_EXTERNAL_LIB)
+    SET(EXTERNAL_LIB_SRC_FILES "")
+ENDIF(INSTALL_EXTERNAL_LIB)
+
 IF(WITH_QPBO)
     SET(QPBO_FILES_EXIST 1)
     SET(QPBO_SRC_FILES
@@ -31,6 +35,9 @@ IF(WITH_QPBO)
             DESTINATION
                 "${CMAKE_BINARY_DIR}/include/opengm/inference/external/qpbo/"
         )
+        IF(INSTALL_EXTERNAL_LIB)
+            LIST(APPEND EXTERNAL_LIB_SRC_FILES ${QPBO_SRC_FILES})
+        ENDIF(INSTALL_EXTERNAL_LIB)
     ELSE(DEFINED QPBO_FILES_EXIST)
         MESSAGE("QPBO not installed, run make externalLibs first and configure again")
     ENDIF(DEFINED QPBO_FILES_EXIST)
@@ -543,3 +550,13 @@ if(WITH_BLOSSOM5)
   ADD_LIBRARY(opengm-external-blossom5-shared   SHARED ${BLOSSOM5_SRC_FILES} )
 
 endif(WITH_BLOSSOM5)
+
+IF(INSTALL_EXTERNAL_LIB AND EXTERNAL_LIB_SRC_FILES)
+    ADD_LIBRARY(opengm-external ${EXTERNAL_LIB_SRC_FILES})
+    ADD_LIBRARY(opengm-external-shared SHARED ${EXTERNAL_LIB_SRC_FILES})
+    INSTALL(TARGETS opengm-external opengm-external-shared
+        RUNTIME DESTINATION bin
+        LIBRARY DESTINATION lib
+        ARCHIVE DESTINATION lib
+    )
+ENDIF(INSTALL_EXTERNAL_LIB AND EXTERNAL_LIB_SRC_FILES)

--- a/src/external/CMakeLists.txt
+++ b/src/external/CMakeLists.txt
@@ -7,15 +7,15 @@ IF(WITH_QPBO)
         ${QPBO_PATCHEDSRCDIR}/QPBO_maxflow.cpp
         ${QPBO_PATCHEDSRCDIR}/QPBO_postprocessing.cpp
     )
-    
+
     SET(QPBO_SRC_FILES_EXIST 1)
     FOREACH(f ${QPBO_SRC_FILES})
         IF(NOT EXISTS ${f})
             UNSET(QPBO_SRC_FILES_EXIST)
         ENDIF(NOT EXISTS ${f})
     ENDFOREACH(f)
-     
-    IF(DEFINED QPBO_SRC_FILES_EXIST)    
+
+    IF(DEFINED QPBO_SRC_FILES_EXIST)
       ADD_LIBRARY(external-library-qpbo
                   ${QPBO_SRC_FILES}
       )
@@ -34,15 +34,15 @@ IF(WITH_TRWS)
         ${TRWS_PATCHEDSRCDIR}/ordering.cpp
         ${TRWS_PATCHEDSRCDIR}/treeProbabilities.cpp
     )
-    
+
     SET(TRWS_SRC_FILES_EXIST 1)
     FOREACH(f ${TRWS_SRC_FILES})
         IF(NOT EXISTS ${f})
             UNSET(TRWS_SRC_FILES_EXIST)
         ENDIF(NOT EXISTS ${f})
     ENDFOREACH(f)
-     
-    IF(DEFINED TRWS_SRC_FILES_EXIST)    
+
+    IF(DEFINED TRWS_SRC_FILES_EXIST)
       ADD_LIBRARY(external-library-trws
                   ${TRWS_SRC_FILES}
       )
@@ -61,20 +61,20 @@ IF(WITH_GCO)
         ${GCO_PATCHEDSRCDIR}/graph.cpp
         ${GCO_PATCHEDSRCDIR}/LinkedBlockList.cpp
         ${GCO_PATCHEDSRCDIR}/maxflow.cpp
-	${GCO_PATCHEDSRCDIR}/instances.inc
+    ${GCO_PATCHEDSRCDIR}/instances.inc
     )
-    
+
     SET(GCO_SRC_FILES_EXIST 1)
     FOREACH(f ${GCO_SRC_FILES})
         IF(NOT EXISTS ${f})
             UNSET(GCO_SRC_FILES_EXIST)
         ENDIF(NOT EXISTS ${f})
     ENDFOREACH(f)
-     
-    IF(DEFINED GCO_SRC_FILES_EXIST)    
+
+    IF(DEFINED GCO_SRC_FILES_EXIST)
       ADD_LIBRARY(external-library-gco
                   ${GCO_SRC_FILES}
-      ) 
+      )
       ADD_LIBRARY(external-library-gco-shared SHARED
                   ${GCO_SRC_FILES}
       )
@@ -88,21 +88,21 @@ IF(WITH_MAXFLOW)
         ${MAXFLOW_PATCHEDSRCDIR}/graph.cpp
         ${MAXFLOW_PATCHEDSRCDIR}/maxflow.cpp
     )
-    
+
     SET(MAXFLOW_SRC_FILES_EXIST 1)
     FOREACH(f ${MAXFLOW_SRC_FILES})
         IF(NOT EXISTS ${f})
             UNSET(MAXFLOW_SRC_FILES_EXIST)
         ENDIF(NOT EXISTS ${f})
     ENDFOREACH(f)
-     
-    IF(DEFINED MAXFLOW_SRC_FILES_EXIST)    
+
+    IF(DEFINED MAXFLOW_SRC_FILES_EXIST)
       ADD_LIBRARY(external-library-maxflow
                   ${MAXFLOW_SRC_FILES}
       )
       ADD_LIBRARY(external-library-maxflow-shared SHARED
                   ${MAXFLOW_SRC_FILES}
-      )  
+      )
     ELSE(DEFINED MAXFLOW_SRC_FILES_EXIST)
         MESSAGE ("MAXFLOW not installed, run make externalLibs first and configure again")
     ENDIF(DEFINED MAXFLOW_SRC_FILES_EXIST)
@@ -118,12 +118,12 @@ IF(WITH_MAXFLOW_IBFS)
             UNSET(MAXFLOW_IBFS_SRC_FILES_EXIST)
         ENDIF(NOT EXISTS ${f})
     ENDFOREACH(f)
-    
-    IF(DEFINED MAXFLOW_IBFS_SRC_FILES_EXIST)    
-      ADD_LIBRARY(external-library-maxflow-ibfs 
+
+    IF(DEFINED MAXFLOW_IBFS_SRC_FILES_EXIST)
+      ADD_LIBRARY(external-library-maxflow-ibfs
                   ${MAXFLOW_IBFS_SRC_FILES}
       )
-      ADD_LIBRARY(external-library-maxflow-ibfs-shared SHARED 
+      ADD_LIBRARY(external-library-maxflow-ibfs-shared SHARED
                   ${MAXFLOW_IBFS_SRC_FILES}
       )
     ELSE(DEFINED MAXFLOW_IBFS_SRC_FILES_EXIST)
@@ -150,11 +150,11 @@ IF(WITH_MRF)
             UNSET(MRF_SRC_FILES_EXIST)
         ENDIF(NOT EXISTS ${f})
     ENDFOREACH(f)
-     
-    IF(DEFINED MRF_SRC_FILES_EXIST)    
+
+    IF(DEFINED MRF_SRC_FILES_EXIST)
       ADD_LIBRARY(external-library-mrf
                   ${MRF_SRC_FILES}
-      ) 
+      )
       ADD_LIBRARY(external-library-mrf-shared SHARED
                   ${MRF_SRC_FILES}
       )
@@ -175,11 +175,11 @@ IF(WITH_FASTPD)
             UNSET(FASTPD_SRC_FILES_EXIST)
         ENDIF(NOT EXISTS ${f})
     ENDFOREACH(f)
-    
-    IF(DEFINED FASTPD_SRC_FILES_EXIST)    
+
+    IF(DEFINED FASTPD_SRC_FILES_EXIST)
       ADD_LIBRARY(external-library-fastpd
                   ${FASTPD_SRC_FILES}
-      ) 
+      )
       ADD_LIBRARY(external-library-fastpd-shared SHARED
                   ${FASTPD_SRC_FILES}
       )
@@ -193,47 +193,47 @@ IF(WITH_GRANTE)
         ${GRANTE_PATCHEDSRCDIR}/Factor.cpp
         ${GRANTE_PATCHEDSRCDIR}/FactorGraph.cpp
         ${GRANTE_PATCHEDSRCDIR}/FactorGraphModel.cpp
-        ${GRANTE_PATCHEDSRCDIR}/FactorType.cpp        
+        ${GRANTE_PATCHEDSRCDIR}/FactorType.cpp
         ${GRANTE_PATCHEDSRCDIR}/FactorGraphStructurizer.cpp
         ${GRANTE_PATCHEDSRCDIR}/DisjointSet.cpp
         ${GRANTE_PATCHEDSRCDIR}/LogSumExp.cpp
-        ${GRANTE_PATCHEDSRCDIR}/TreeInference.cpp        
+        ${GRANTE_PATCHEDSRCDIR}/TreeInference.cpp
         ${GRANTE_PATCHEDSRCDIR}/GibbsSampler.cpp
         ${GRANTE_PATCHEDSRCDIR}/FunctionMinimization.cpp
         ${GRANTE_PATCHEDSRCDIR}/FunctionMinimizationProblem.cpp
-        ${GRANTE_PATCHEDSRCDIR}/Likelihood.cpp        
+        ${GRANTE_PATCHEDSRCDIR}/Likelihood.cpp
         ${GRANTE_PATCHEDSRCDIR}/InferenceMethod.cpp
         ${GRANTE_PATCHEDSRCDIR}/ParameterEstimationMethod.cpp
         ${GRANTE_PATCHEDSRCDIR}/MaximumLikelihood.cpp
-        ${GRANTE_PATCHEDSRCDIR}/FactorGraphObservation.cpp        
+        ${GRANTE_PATCHEDSRCDIR}/FactorGraphObservation.cpp
         ${GRANTE_PATCHEDSRCDIR}/Prior.cpp
         ${GRANTE_PATCHEDSRCDIR}/NormalPrior.cpp
         ${GRANTE_PATCHEDSRCDIR}/LaplacePrior.cpp
-        ${GRANTE_PATCHEDSRCDIR}/MaximumPseudolikelihood.cpp        
+        ${GRANTE_PATCHEDSRCDIR}/MaximumPseudolikelihood.cpp
         ${GRANTE_PATCHEDSRCDIR}/FactorGraphUtility.cpp
         ${GRANTE_PATCHEDSRCDIR}/Pseudolikelihood.cpp
         ${GRANTE_PATCHEDSRCDIR}/StudentTPrior.cpp
-        ${GRANTE_PATCHEDSRCDIR}/StructuredLossFunction.cpp        
+        ${GRANTE_PATCHEDSRCDIR}/StructuredLossFunction.cpp
         ${GRANTE_PATCHEDSRCDIR}/StructuredHammingLoss.cpp
         ${GRANTE_PATCHEDSRCDIR}/StructuredSVM.cpp
         ${GRANTE_PATCHEDSRCDIR}/StochasticFunctionMinimizationProblem.cpp
-        ${GRANTE_PATCHEDSRCDIR}/StochasticFunctionMinimization.cpp        
+        ${GRANTE_PATCHEDSRCDIR}/StochasticFunctionMinimization.cpp
         ${GRANTE_PATCHEDSRCDIR}/StructuredPerceptron.cpp
         ${GRANTE_PATCHEDSRCDIR}/RandomFactorGraphGenerator.cpp
         ${GRANTE_PATCHEDSRCDIR}/VAcyclicDecomposition.cpp
-        ${GRANTE_PATCHEDSRCDIR}/SubFactorGraph.cpp        
+        ${GRANTE_PATCHEDSRCDIR}/SubFactorGraph.cpp
         ${GRANTE_PATCHEDSRCDIR}/FactorConditioningTable.cpp
         ${GRANTE_PATCHEDSRCDIR}/ConditionedFactorType.cpp
         ${GRANTE_PATCHEDSRCDIR}/Conditioning.cpp
-        ${GRANTE_PATCHEDSRCDIR}/MaximumCompositeLikelihood.cpp        
+        ${GRANTE_PATCHEDSRCDIR}/MaximumCompositeLikelihood.cpp
         ${GRANTE_PATCHEDSRCDIR}/TreeCoverDecomposition.cpp
         ${GRANTE_PATCHEDSRCDIR}/LinearProgrammingMAPInference.cpp
         ${GRANTE_PATCHEDSRCDIR}/FactorDataSource.cpp
-        ${GRANTE_PATCHEDSRCDIR}/FactorGraphPartialObservation.cpp        
+        ${GRANTE_PATCHEDSRCDIR}/FactorGraphPartialObservation.cpp
         ${GRANTE_PATCHEDSRCDIR}/BeliefPropagation.cpp
         ${GRANTE_PATCHEDSRCDIR}/RBFNetworkRegression.cpp
         ${GRANTE_PATCHEDSRCDIR}/RBFNetwork.cpp
-        ${GRANTE_PATCHEDSRCDIR}/NonlinearRBFFactorType.cpp        
+        ${GRANTE_PATCHEDSRCDIR}/NonlinearRBFFactorType.cpp
         ${GRANTE_PATCHEDSRCDIR}/GibbsInference.cpp
         ${GRANTE_PATCHEDSRCDIR}/StructuredMeanFieldInference.cpp
         ${GRANTE_PATCHEDSRCDIR}/ExpectationMaximization.cpp
@@ -241,7 +241,7 @@ IF(WITH_GRANTE)
         ${GRANTE_PATCHEDSRCDIR}/AISInference.cpp
         ${GRANTE_PATCHEDSRCDIR}/SimulatedAnnealingInference.cpp
         ${GRANTE_PATCHEDSRCDIR}/MaximumCrissCrossLikelihood.cpp
-        ${GRANTE_PATCHEDSRCDIR}/DiffusionInference.cpp        
+        ${GRANTE_PATCHEDSRCDIR}/DiffusionInference.cpp
         ${GRANTE_PATCHEDSRCDIR}/BruteForceExactInference.cpp
         ${GRANTE_PATCHEDSRCDIR}/LinearFactorType.cpp
         ${GRANTE_PATCHEDSRCDIR}/NaivePiecewiseTraining.cpp
@@ -249,27 +249,27 @@ IF(WITH_GRANTE)
         ${GRANTE_PATCHEDSRCDIR}/ContrastiveDivergenceTraining.cpp
         ${GRANTE_PATCHEDSRCDIR}/HyperbolicPrior.cpp
         ${GRANTE_PATCHEDSRCDIR}/CompositeMinimization.cpp
-        ${GRANTE_PATCHEDSRCDIR}/CompositeMinimizationProblem.cpp        
+        ${GRANTE_PATCHEDSRCDIR}/CompositeMinimizationProblem.cpp
         ${GRANTE_PATCHEDSRCDIR}/SwendsenWangSampler.cpp
         ${GRANTE_PATCHEDSRCDIR}/SwendsenWangInference.cpp
         ${GRANTE_PATCHEDSRCDIR}/ParallelTemperingInference.cpp
-        ${GRANTE_PATCHEDSRCDIR}/SAMCInference.cpp        
+        ${GRANTE_PATCHEDSRCDIR}/SAMCInference.cpp
         ${GRANTE_PATCHEDSRCDIR}/TestModels.cpp
         ${GRANTE_PATCHEDSRCDIR}/NaiveMeanFieldInference.cpp
         ${GRANTE_PATCHEDSRCDIR}/MaximumTreePseudoLikelihood.cpp
-        ${GRANTE_PATCHEDSRCDIR}/DisjointSetBT.cpp        
+        ${GRANTE_PATCHEDSRCDIR}/DisjointSetBT.cpp
         ${GRANTE_PATCHEDSRCDIR}/MultichainGibbsInference.cpp
     )
-    
+
     SET(GRANTE_SRC_FILES_EXIST 1)
     FOREACH(f ${GRANTE_SRC_FILES})
         IF(NOT EXISTS ${f})
             UNSET(GRANTE_SRC_FILES_EXIST)
         ENDIF(NOT EXISTS ${f})
     ENDFOREACH(f)
-    
+
     IF(DEFINED GRANTE_SRC_FILES_EXIST)
-      add_definitions(-fopenmp -fno-omit-frame-pointer -std=c++0x)    
+      add_definitions(-fopenmp -fno-omit-frame-pointer -std=c++0x)
       ADD_LIBRARY(external-library-grante
                   ${GRANTE_SRC_FILES}
       )
@@ -298,7 +298,7 @@ IF(WITH_AD3)
     include_directories( ${AD3_PATCHEDSRCDIR}/Eigen )
     ADD_LIBRARY(external-library-ad3   ${AD3_SRC_FILES})
     ADD_LIBRARY(external-library-ad3-shared   SHARED ${AD3_SRC_FILES} )
-      
+
 
   ELSE(DEFINED AD3_SRC_FILES_EXIST)
     MESSAGE ("Ad3 not installed, run make externalLibs first and configure again")
@@ -327,14 +327,14 @@ IF(WITH_DAOOPT)
       ${DAOOPT_SRCDIR}/lib/zlib/uncompr.c
       ${DAOOPT_SRCDIR}/lib/zlib/zutil.c
    )
-   
+
    # GzStream source files
    set(DAOOPT_GZSTREAM_SRC_FILES
       ${DAOOPT_SRCDIR}/lib/gzstream.cpp
-   )  
+   )
 
    # SLS4MPE source files
-   set(DAOOPT_SLS4MPE_SRC_FILES   
+   set(DAOOPT_SLS4MPE_SRC_FILES
       ${DAOOPT_SRCDIR}/lib/sls4mpe/AssignmentManager.cpp
       ${DAOOPT_SRCDIR}/lib/sls4mpe/Bucket.cpp
       ${DAOOPT_SRCDIR}/lib/sls4mpe/fheap.cpp
@@ -347,7 +347,7 @@ IF(WITH_DAOOPT)
       ${DAOOPT_SRCDIR}/lib/sls4mpe/timer.cpp
       ${DAOOPT_SRCDIR}/lib/sls4mpe/Variable.cpp
    )
-   
+
    # Main daoopt source files
    set(DAOOPT_SRC_FILES
       ${DAOOPT_SRCDIR}/source/BestFirst.cpp
@@ -380,7 +380,7 @@ IF(WITH_DAOOPT)
       ${DAOOPT_SRCDIR}/source/SubprobStats.cpp
       ${DAOOPT_SRCDIR}/source/utils.cpp
    )
-   
+
     SET(DAOOPT_SRC_FILES_EXIST 1)
     FOREACH(f ${DAOOPT_ZLIB_SRC_FILES})
         IF(NOT EXISTS ${f})
@@ -402,7 +402,7 @@ IF(WITH_DAOOPT)
             UNSET(DAOOPT_SRC_FILES_EXIST)
         ENDIF(NOT EXISTS ${f})
     ENDFOREACH(f)
-    
+
     IF(DEFINED DAOOPT_SRC_FILES_EXIST)
       ADD_LIBRARY(external-library-daoopt
                   ${DAOOPT_SRC_FILES}
@@ -414,23 +414,23 @@ IF(WITH_DAOOPT)
                   ${DAOOPT_SRC_FILES}
                   ${DAOOPT_ZLIB_SRC_FILES}
                   ${DAOOPT_GZSTREAM_SRC_FILES}
-                  ${DAOOPT_SLS4MPE_SRC_FILES}              
+                  ${DAOOPT_SLS4MPE_SRC_FILES}
       )
-      
+
       target_link_libraries(external-library-daoopt
          ${CMAKE_THREAD_LIBS_INIT}
          ${Boost_PROGRAM_OPTIONS_LIBRARY}
          ${Boost_THREAD_LIBRARY}
-         ${Boost_SYSTEM_LIBRARY}  
-         ${HDF5_LIBRARIES}      
+         ${Boost_SYSTEM_LIBRARY}
+         ${HDF5_LIBRARIES}
       )
-      
+
       target_link_libraries(external-library-daoopt-shared
          ${CMAKE_THREAD_LIBS_INIT}
          ${Boost_PROGRAM_OPTIONS_LIBRARY}
          ${Boost_THREAD_LIBRARY}
-         ${Boost_SYSTEM_LIBRARY}  
-         ${HDF5_LIBRARIES}      
+         ${Boost_SYSTEM_LIBRARY}
+         ${HDF5_LIBRARIES}
       )
     ELSE(DEFINED DAOOPT_SRC_FILES_EXIST)
         MESSAGE ("DAOOPT not installed, run make externalLibs first and configure again")
@@ -450,11 +450,11 @@ IF(WITH_MPLP)
             UNSET(MPLP_SRC_FILES_EXIST)
         ENDIF(NOT EXISTS ${f})
     ENDFOREACH(f)
-    
-    IF(DEFINED MPLP_SRC_FILES_EXIST)    
+
+    IF(DEFINED MPLP_SRC_FILES_EXIST)
       ADD_LIBRARY(external-library-mplp
                   ${MPLP_SRC_FILES}
-      ) 
+      )
       ADD_LIBRARY(external-library-mplp-shared SHARED
                   ${MPLP_SRC_FILES}
       )
@@ -486,11 +486,11 @@ if(WITH_SRMP)
             UNSET(SRMP_SRC_FILES_EXIST)
         ENDIF(NOT EXISTS ${f})
     ENDFOREACH(f)
-    
-    IF(DEFINED SRMP_SRC_FILES_EXIST)    
+
+    IF(DEFINED SRMP_SRC_FILES_EXIST)
       ADD_LIBRARY(external-library-srmp
                   ${SRMP_SRC_FILES}
-      ) 
+      )
       ADD_LIBRARY(external-library-srmp-shared SHARED
                   ${SRMP_SRC_FILES}
       )
@@ -500,7 +500,7 @@ if(WITH_SRMP)
 endif(WITH_SRMP)
 
 if(WITH_PLANARITY)
-  SET(PLANARITY_SRC_FILES 
+  SET(PLANARITY_SRC_FILES
      ${PLANARITY_PATCHEDSRCDIR}/graphNonplanar.c
      ${PLANARITY_PATCHEDSRCDIR}/graphIsolator.c
      ${PLANARITY_PATCHEDSRCDIR}/graphEmbed.c
@@ -509,16 +509,16 @@ if(WITH_PLANARITY)
      ${PLANARITY_PATCHEDSRCDIR}/graphStructure.c
      ${PLANARITY_PATCHEDSRCDIR}/graphPreprocess.c
   )
-  
-  
+
+
   ADD_LIBRARY(opengm-external-planarity   ${PLANARITY_SRC_FILES})
-  ADD_LIBRARY(opengm-external-planarity-shared   SHARED ${PLANARITY_SRC_FILES} ) 
+  ADD_LIBRARY(opengm-external-planarity-shared   SHARED ${PLANARITY_SRC_FILES} )
 
 endif(WITH_PLANARITY)
 
 if(WITH_BLOSSOM5)
-  
-  SET(BLOSSOM5_SRC_FILES 
+
+  SET(BLOSSOM5_SRC_FILES
     ${BLOSSOM5_PATCHEDSRCDIR}/misc.cpp
     ${BLOSSOM5_PATCHEDSRCDIR}/PMduals.cpp
     ${BLOSSOM5_PATCHEDSRCDIR}/PMexpand.cpp
@@ -532,5 +532,5 @@ if(WITH_BLOSSOM5)
 
   ADD_LIBRARY(opengm-external-blossom5   ${BLOSSOM5_SRC_FILES})
   ADD_LIBRARY(opengm-external-blossom5-shared   SHARED ${BLOSSOM5_SRC_FILES} )
- 
+
 endif(WITH_BLOSSOM5)

--- a/src/external/CMakeLists.txt
+++ b/src/external/CMakeLists.txt
@@ -1,30 +1,39 @@
 add_subdirectory(patches)
 
 IF(WITH_QPBO)
+    SET(QPBO_FILES_EXIST 1)
     SET(QPBO_SRC_FILES
         ${QPBO_PATCHEDSRCDIR}/QPBO_extra.cpp
         ${QPBO_PATCHEDSRCDIR}/QPBO.cpp
         ${QPBO_PATCHEDSRCDIR}/QPBO_maxflow.cpp
         ${QPBO_PATCHEDSRCDIR}/QPBO_postprocessing.cpp
     )
-
-    SET(QPBO_SRC_FILES_EXIST 1)
     FOREACH(f ${QPBO_SRC_FILES})
         IF(NOT EXISTS ${f})
-            UNSET(QPBO_SRC_FILES_EXIST)
+            UNSET(QPBO_FILES_EXIST)
         ENDIF(NOT EXISTS ${f})
     ENDFOREACH(f)
-
-    IF(DEFINED QPBO_SRC_FILES_EXIST)
-      ADD_LIBRARY(external-library-qpbo
-                  ${QPBO_SRC_FILES}
-      )
-      ADD_LIBRARY(external-library-qpbo-shared SHARED
-                  ${QPBO_SRC_FILES}
-      )
-    ELSE(DEFINED QPBO_SRC_FILES_EXIST)
-        MESSAGE ("QPBO not installed, run make externalLibs first and configure again")
-    ENDIF(DEFINED QPBO_SRC_FILES_EXIST)
+    SET(QPBO_INCL_FILES
+        ${QPBO_PATCHEDSRCDIR}/block.h
+        ${QPBO_PATCHEDSRCDIR}/QPBO.h
+    )
+    FOREACH(f ${QPBO_INCL_FILES})
+        IF(NOT EXISTS ${f})
+            UNSET(QPBO_FILES_EXIST)
+        ENDIF(NOT EXISTS ${f})
+    ENDFOREACH(f)
+    IF(DEFINED QPBO_FILES_EXIST)
+        ADD_LIBRARY(external-library-qpbo ${QPBO_SRC_FILES})
+        ADD_LIBRARY(external-library-qpbo-shared SHARED ${QPBO_SRC_FILES})
+        FILE(
+            COPY
+                ${QPBO_INCL_FILES}
+            DESTINATION
+                "${CMAKE_BINARY_DIR}/include/opengm/inference/external/qpbo/"
+        )
+    ELSE(DEFINED QPBO_FILES_EXIST)
+        MESSAGE("QPBO not installed, run make externalLibs first and configure again")
+    ENDIF(DEFINED QPBO_FILES_EXIST)
 ENDIF()
 
 IF(WITH_TRWS)

--- a/src/external/patches/QPBO/QPBO-v1.3.patch
+++ b/src/external/patches/QPBO/QPBO-v1.3.patch
@@ -1,85 +1,135 @@
 diff -rupN QPBO-v1.3.src/QPBO.cpp QPBO-v1.3.src-patched/QPBO.cpp
---- QPBO-v1.3.src/QPBO.cpp	2010-01-25 16:38:59.000000000 +0100
-+++ QPBO-v1.3.src-patched/QPBO.cpp	2013-05-23 19:59:56.226606473 +0200
-@@ -6,6 +6,8 @@
+--- QPBO-v1.3.src/QPBO.cpp  2010-01-25 10:38:59.000000000 -0500
++++ QPBO-v1.3.src-patched/QPBO.cpp  2016-07-25 14:35:33.253091828 -0400
+@@ -4,8 +4,10 @@
+ #include <stdio.h>
+ #include <stdlib.h>
  #include <string.h>
- #include "QPBO.h"
+-#include "QPBO.h"
++#include "opengm/inference/external/qpbo/QPBO.h"
  
 +namespace kolmogorov{
 +namespace qpbo{
  
  template <typename REAL> 
- 	QPBO<REAL>::QPBO(int node_num_max, int edge_num_max, void (*err_function)(char *))
+    QPBO<REAL>::QPBO(int node_num_max, int edge_num_max, void (*err_function)(char *))
 @@ -24,7 +26,7 @@ template <typename REAL>
  
- 	nodes[0] = (Node*) malloc(2*node_num_max*sizeof(Node));
- 	arcs[0] = (Arc*) malloc(4*edge_num_max*sizeof(Arc));
--	if (!nodes[0] || !arcs[0]) { if (error_function) (*error_function)("Not enough memory!"); exit(1); }
-+	if (!nodes[0] || !arcs[0]) { if (error_function) (*error_function)((char*)("Not enough memory!")); exit(1); }
+    nodes[0] = (Node*) malloc(2*node_num_max*sizeof(Node));
+    arcs[0] = (Arc*) malloc(4*edge_num_max*sizeof(Arc));
+-   if (!nodes[0] || !arcs[0]) { if (error_function) (*error_function)("Not enough memory!"); exit(1); }
++   if (!nodes[0] || !arcs[0]) { if (error_function) (*error_function)((char*)("Not enough memory!")); exit(1); }
  
- 	node_last[0] = nodes[0];
- 	node_max[0] = nodes[1] = node_last[1] = nodes[0] + node_num_max;
+    node_last[0] = nodes[0];
+    node_max[0] = nodes[1] = node_last[1] = nodes[0] + node_num_max;
 @@ -76,7 +78,7 @@ template <typename REAL>
  
- 	nodes[0] = (Node*) malloc(2*node_num_max*sizeof(Node));
- 	arcs[0] = (Arc*) malloc(2*arc_num_max*sizeof(Arc));
--	if (!nodes[0] || !arcs[0]) { if (error_function) (*error_function)("Not enough memory!"); exit(1); }
-+	if (!nodes[0] || !arcs[0]) { if (error_function) (*error_function)((char*)("Not enough memory!")); exit(1); }
+    nodes[0] = (Node*) malloc(2*node_num_max*sizeof(Node));
+    arcs[0] = (Arc*) malloc(2*arc_num_max*sizeof(Arc));
+-   if (!nodes[0] || !arcs[0]) { if (error_function) (*error_function)("Not enough memory!"); exit(1); }
++   if (!nodes[0] || !arcs[0]) { if (error_function) (*error_function)((char*)("Not enough memory!")); exit(1); }
  
- 	node_last[0] = nodes[0] + node_num;
- 	node_max[0] = nodes[1] = nodes[0] + node_num_max;
+    node_last[0] = nodes[0] + node_num;
+    node_max[0] = nodes[1] = nodes[0] + node_num_max;
 @@ -176,7 +178,7 @@ template <typename REAL>
  
- 	int node_num_max = node_num_max_new;
- 	nodes[0] = (Node*) realloc(nodes_old[0], 2*node_num_max*sizeof(Node));
--	if (!nodes[0]) { if (error_function) (*error_function)("Not enough memory!"); exit(1); }
-+	if (!nodes[0]) { if (error_function) (*error_function)((char*)("Not enough memory!")); exit(1); }
+    int node_num_max = node_num_max_new;
+    nodes[0] = (Node*) realloc(nodes_old[0], 2*node_num_max*sizeof(Node));
+-   if (!nodes[0]) { if (error_function) (*error_function)("Not enough memory!"); exit(1); }
++   if (!nodes[0]) { if (error_function) (*error_function)((char*)("Not enough memory!")); exit(1); }
  
- 	node_shift = node_num_max*sizeof(Node);
- 	node_last[0] = nodes[0] + node_num;
+    node_shift = node_num_max*sizeof(Node);
+    node_last[0] = nodes[0] + node_num;
 @@ -208,7 +210,7 @@ template <typename REAL>
- 	Arc* arcs_old[2] = { arcs[0], arcs[1] };
+    Arc* arcs_old[2] = { arcs[0], arcs[1] };
  
- 	arcs[0] = (Arc*) realloc(arcs_old[0], 2*arc_num_max*sizeof(Arc));
--	if (!arcs[0]) { if (error_function) (*error_function)("Not enough memory!"); exit(1); }
-+	if (!arcs[0]) { if (error_function) (*error_function)((char*)("Not enough memory!")); exit(1); }
+    arcs[0] = (Arc*) realloc(arcs_old[0], 2*arc_num_max*sizeof(Arc));
+-   if (!arcs[0]) { if (error_function) (*error_function)("Not enough memory!"); exit(1); }
++   if (!arcs[0]) { if (error_function) (*error_function)((char*)("Not enough memory!")); exit(1); }
  
- 	arc_shift = arc_num_max*sizeof(Arc);
- 	arc_max[0] = arcs[1] = arcs[0] + arc_num_max;
+    arc_shift = arc_num_max*sizeof(Arc);
+    arc_max[0] = arcs[1] = arcs[0] + arc_num_max;
 @@ -330,12 +332,12 @@ template <typename REAL>
- 				if (IsNode0(a->head)) delta += a->sister->r_cap + GetMate(a)->sister->r_cap;
- 				else                  delta -= a->r_cap + GetMate(a)->r_cap;
- 			}
--			fprintf(fp, "1 %d %d\n", i+1, delta);
-+			fprintf(fp, "1 %d %d\n", i+1, (int)(delta));
- 		}
- 		for (e=GetNextEdgeId(-1); e>=0; e=GetNextEdgeId(e))
- 		{
- 			GetTwicePairwiseTerm(e, i, j, E00, E01, E10, E11);
--			fprintf(fp, "2 %d %d %d\n", i+1, j+1, E00 + E11 - E01 - E10);
-+			fprintf(fp, "2 %d %d %d\n", i+1, j+1, int(E00 + E11 - E01 - E10));
- 		}
- 		fclose(fp);
- 		return true;
+                if (IsNode0(a->head)) delta += a->sister->r_cap + GetMate(a)->sister->r_cap;
+                else                  delta -= a->r_cap + GetMate(a)->r_cap;
+            }
+-           fprintf(fp, "1 %d %d\n", i+1, delta);
++           fprintf(fp, "1 %d %d\n", i+1, (int)(delta));
+        }
+        for (e=GetNextEdgeId(-1); e>=0; e=GetNextEdgeId(e))
+        {
+            GetTwicePairwiseTerm(e, i, j, E00, E01, E10, E11);
+-           fprintf(fp, "2 %d %d %d\n", i+1, j+1, E00 + E11 - E01 - E10);
++           fprintf(fp, "2 %d %d %d\n", i+1, j+1, int(E00 + E11 - E01 - E10));
+        }
+        fclose(fp);
+        return true;
 @@ -940,4 +942,5 @@ template <typename REAL>
- 	}
+    }
  }
  
 +}}
  #include "instances.inc"
+diff -rupN QPBO-v1.3.src/QPBO_extra.cpp QPBO-v1.3.src-patched/QPBO_extra.cpp
+--- QPBO-v1.3.src/QPBO_extra.cpp    2010-01-25 10:38:59.000000000 -0500
++++ QPBO-v1.3.src-patched/QPBO_extra.cpp    2016-07-25 14:35:33.253091828 -0400
+@@ -4,11 +4,13 @@
+ #include <stdio.h>
+ #include <stdlib.h>
+ #include <string.h>
+-#include "QPBO.h"
++#include "opengm/inference/external/qpbo/QPBO.h"
+ 
+ /////////////////////////////////////////////////////////////////////////
+ /////////////////////////////////////////////////////////////////////////
+ /////////////////////////////////////////////////////////////////////////
++namespace kolmogorov{
++namespace qpbo{
+ 
+ template <typename REAL>
+    void QPBO<REAL>::ComputeRandomPermutation(int N, int* permutation)
+@@ -1109,10 +1111,9 @@ template <typename REAL>
+    user_terminated = false;
+ 
+    memcpy(&probe_options, &options, sizeof(ProbeOptions));
++       is_enough_memory = Probe(mapping);
+ 
+-   is_enough_memory = Probe(mapping);
+-
+-   while ( 1 )
++       while ( 1 )
+    {
+        if (user_terminated) break;
+ 
+@@ -1145,7 +1146,7 @@ template <typename REAL>
+        is_enough_memory = Probe(mapping1);
+        MergeMappings(nodeNum0, mapping, mapping1);
+        delete [] mapping1;
+-   }
++   } 
+ }
+ 
+ template <typename REAL>
+@@ -1230,5 +1231,5 @@ template <typename REAL>
+    delete [] permutation;
+    return success;
+ }
+-
++}}
+ #include "instances.inc"
 diff -rupN QPBO-v1.3.src/QPBO.h QPBO-v1.3.src-patched/QPBO.h
---- QPBO-v1.3.src/QPBO.h	2010-01-25 16:41:14.000000000 +0100
-+++ QPBO-v1.3.src-patched/QPBO.h	2013-05-23 19:59:56.226606473 +0200
+--- QPBO-v1.3.src/QPBO.h    2010-01-25 10:41:14.000000000 -0500
++++ QPBO-v1.3.src-patched/QPBO.h    2016-07-25 14:35:33.253091828 -0400
 @@ -1,13 +1,11 @@
  /* QBPO.h */
  /*
- 	Version 1.3
+    Version 1.3
 -
 -    Copyright 2006-2008 Vladimir Kolmogorov (vnk@adastral.ucl.ac.uk).
 +   Copyright 2006-2008 Vladimir Kolmogorov (vnk@adastral.ucl.ac.uk).
      This software can be used for research purposes only.
- 	This software or its derivatives must not be publicly distributed
- 	without a prior consent from the author (Vladimir Kolmogorov).
+    This software or its derivatives must not be publicly distributed
+    without a prior consent from the author (Vladimir Kolmogorov).
 -
 -    THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
 +   THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
@@ -88,13 +138,13 @@ diff -rupN QPBO-v1.3.src/QPBO.h QPBO-v1.3.src-patched/QPBO.h
      A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT
 @@ -38,7 +36,7 @@
  
- 		P. L. Hammer, P. Hansen, and B. Simeone. 
- 		Roof duality, complementation and persistency in quadratic 0-1 optimization. 
--		Mathematical Programming, 28:121–155, 1984.
-+		Mathematical Programming, 28:121ï¿½155, 1984.
+        P. L. Hammer, P. Hansen, and B. Simeone. 
+        Roof duality, complementation and persistency in quadratic 0-1 optimization. 
+-       Mathematical Programming, 28:121–155, 1984.
++       Mathematical Programming, 28:121ï¿½155, 1984.
  
- 		E. Boros, P. L. Hammer, and X. Sun.
- 		Network flows and minimization of quadratic pseudo-Boolean functions. 
+        E. Boros, P. L. Hammer, and X. Sun.
+        Network flows and minimization of quadratic pseudo-Boolean functions. 
 @@ -120,7 +118,8 @@
  // #define user_assert(ignore)((void) 0) 
  // #define code_assert(ignore)((void) 0) 
@@ -106,106 +156,71 @@ diff -rupN QPBO-v1.3.src/QPBO.h QPBO-v1.3.src-patched/QPBO.h
  // REAL: can be int, float, double.
  // Current instantiations are in instances.inc
 @@ -263,7 +262,7 @@ public:
- 	//
- 	//         A. Billionnet and B. Jaumard. 
- 	//         A decomposition method for minimizing quadratic pseudoboolean functions. 
--	//         Operation Research Letters, 8:161–163, 1989.	
-+	//         Operation Research Letters, 8:161ï¿½163, 1989.	
- 	//
- 	//     For a review see also 
- 	//
+    //
+    //         A. Billionnet and B. Jaumard. 
+    //         A decomposition method for minimizing quadratic pseudoboolean functions. 
+-   //         Operation Research Letters, 8:161–163, 1989. 
++   //         Operation Research Letters, 8:161ï¿½163, 1989.   
+    //
+    //     For a review see also 
+    //
 @@ -811,5 +810,5 @@ template <typename REAL>
  */
- #define QPBO_MAXFLOW_TERMINAL ( (Arc *) 1 )		/* to terminal */
- #define QPBO_MAXFLOW_ORPHAN   ( (Arc *) 2 )		/* orphan */
+ #define QPBO_MAXFLOW_TERMINAL ( (Arc *) 1 )        /* to terminal */
+ #define QPBO_MAXFLOW_ORPHAN   ( (Arc *) 2 )        /* orphan */
 -
 +}}
  #endif
-diff -rupN QPBO-v1.3.src/QPBO_extra.cpp QPBO-v1.3.src-patched/QPBO_extra.cpp
---- QPBO-v1.3.src/QPBO_extra.cpp	2010-01-25 16:38:59.000000000 +0100
-+++ QPBO-v1.3.src-patched/QPBO_extra.cpp	2013-05-23 19:59:56.226606473 +0200
-@@ -9,6 +9,8 @@
- /////////////////////////////////////////////////////////////////////////
- /////////////////////////////////////////////////////////////////////////
- /////////////////////////////////////////////////////////////////////////
-+namespace kolmogorov{
-+namespace qpbo{
- 
- template <typename REAL>
- 	void QPBO<REAL>::ComputeRandomPermutation(int N, int* permutation)
-@@ -1109,10 +1111,9 @@ template <typename REAL>
- 	user_terminated = false;
- 
- 	memcpy(&probe_options, &options, sizeof(ProbeOptions));
-+      	is_enough_memory = Probe(mapping);
- 
--	is_enough_memory = Probe(mapping);
--
--	while ( 1 )
-+      	while ( 1 )
- 	{
- 		if (user_terminated) break;
- 
-@@ -1145,7 +1146,7 @@ template <typename REAL>
- 		is_enough_memory = Probe(mapping1);
- 		MergeMappings(nodeNum0, mapping, mapping1);
- 		delete [] mapping1;
--	}
-+	} 
- }
- 
- template <typename REAL>
-@@ -1230,5 +1231,5 @@ template <typename REAL>
- 	delete [] permutation;
- 	return success;
- }
--
-+}}
- #include "instances.inc"
 diff -rupN QPBO-v1.3.src/QPBO_maxflow.cpp QPBO-v1.3.src-patched/QPBO_maxflow.cpp
---- QPBO-v1.3.src/QPBO_maxflow.cpp	2010-01-25 16:38:59.000000000 +0100
-+++ QPBO-v1.3.src-patched/QPBO_maxflow.cpp	2013-05-23 19:59:56.226606473 +0200
-@@ -4,7 +4,8 @@
- #include <stdio.h>
- #include "QPBO.h"
+--- QPBO-v1.3.src/QPBO_maxflow.cpp  2010-01-25 10:38:59.000000000 -0500
++++ QPBO-v1.3.src-patched/QPBO_maxflow.cpp  2016-07-25 14:35:33.253091828 -0400
+@@ -2,9 +2,10 @@
  
+ 
+ #include <stdio.h>
+-#include "QPBO.h"
 -
++#include "opengm/inference/external/qpbo/QPBO.h"
+ 
 +namespace kolmogorov{
 +namespace qpbo{
  
- #define INFINITE_D ((int)(((unsigned)-1)/2))		/* infinite distance to the terminal */
+ #define INFINITE_D ((int)(((unsigned)-1)/2))       /* infinite distance to the terminal */
  
 @@ -704,5 +705,5 @@ template <typename REAL>
- 		}
- 	}
+        }
+    }
  }
 -
 +}}
  #include "instances.inc"
 diff -rupN QPBO-v1.3.src/QPBO_postprocessing.cpp QPBO-v1.3.src-patched/QPBO_postprocessing.cpp
---- QPBO-v1.3.src/QPBO_postprocessing.cpp	2010-01-25 16:38:59.000000000 +0100
-+++ QPBO-v1.3.src-patched/QPBO_postprocessing.cpp	2013-05-23 19:59:56.226606473 +0200
-@@ -6,6 +6,8 @@
+--- QPBO-v1.3.src/QPBO_postprocessing.cpp   2010-01-25 10:38:59.000000000 -0500
++++ QPBO-v1.3.src-patched/QPBO_postprocessing.cpp   2016-07-25 14:35:33.253091828 -0400
+@@ -4,8 +4,10 @@
+ #include <stdio.h>
+ #include <stdlib.h>
  #include <string.h>
- #include "QPBO.h"
+-#include "QPBO.h"
++#include "opengm/inference/external/qpbo/QPBO.h"
  
 +namespace kolmogorov{
 +namespace qpbo{
  
  template <typename REAL>
- 	void QPBO<REAL>::ComputeWeakPersistencies()
+    void QPBO<REAL>::ComputeWeakPersistencies()
 @@ -167,5 +169,5 @@ template <typename REAL>
  
- 	ComputeWeakPersistencies();
+    ComputeWeakPersistencies();
  }
 -
 +}}
  #include "instances.inc"
 diff -rupN QPBO-v1.3.src/block.h QPBO-v1.3.src-patched/block.h
---- QPBO-v1.3.src/block.h	2010-01-25 16:39:21.000000000 +0100
-+++ QPBO-v1.3.src-patched/block.h	2013-05-23 19:59:56.226606473 +0200
+--- QPBO-v1.3.src/block.h   2010-01-25 10:39:21.000000000 -0500
++++ QPBO-v1.3.src-patched/block.h   2016-07-25 14:35:33.253091828 -0400
 @@ -87,8 +87,8 @@
- 	deallocated only when the destructor is called.
+    deallocated only when the destructor is called.
  */
  
 -#ifndef __BLOCK_H__
@@ -226,25 +241,25 @@ diff -rupN QPBO-v1.3.src/block.h QPBO-v1.3.src-patched/block.h
  {
  public:
 @@ -121,7 +124,7 @@ public:
- 			else
- 			{
- 				block *next = (block *) new char [sizeof(block) + (block_size-1)*sizeof(Type)];
--				if (!next) { if (error_function) (*error_function)("Not enough memory!"); exit(1); }
-+				if (!next) { if (error_function) (*error_function)((char*)("Not enough memory!")); exit(1); }
- 				if (last) last -> next = next;
- 				else first = next;
- 				last = next;
+            else
+            {
+                block *next = (block *) new char [sizeof(block) + (block_size-1)*sizeof(Type)];
+-               if (!next) { if (error_function) (*error_function)("Not enough memory!"); exit(1); }
++               if (!next) { if (error_function) (*error_function)((char*)("Not enough memory!")); exit(1); }
+                if (last) last -> next = next;
+                else first = next;
+                last = next;
 @@ -220,7 +223,7 @@ public:
- 		{
- 			block *next = first;
- 			first = (block *) new char [sizeof(block) + (block_size-1)*sizeof(block_item)];
--			if (!first) { if (error_function) (*error_function)("Not enough memory!"); exit(1); }
-+			if (!first) { if (error_function) (*error_function)((char*)("Not enough memory!")); exit(1); }
- 			first_free = & (first -> data[0] );
- 			for (item=first_free; item<first_free+block_size-1; item++)
- 				item -> next_free = item + 1;
+        {
+            block *next = first;
+            first = (block *) new char [sizeof(block) + (block_size-1)*sizeof(block_item)];
+-           if (!first) { if (error_function) (*error_function)("Not enough memory!"); exit(1); }
++           if (!first) { if (error_function) (*error_function)((char*)("Not enough memory!")); exit(1); }
+            first_free = & (first -> data[0] );
+            for (item=first_free; item<first_free+block_size-1; item++)
+                item -> next_free = item + 1;
 @@ -263,6 +266,8 @@ private:
- 	void	(*error_function)(char *);
+    void    (*error_function)(char *);
  };
  
 +} //namespace qpbo
@@ -253,8 +268,8 @@ diff -rupN QPBO-v1.3.src/block.h QPBO-v1.3.src-patched/block.h
  #endif
  
 diff -rupN QPBO-v1.3.src/instances.inc QPBO-v1.3.src-patched/instances.inc
---- QPBO-v1.3.src/instances.inc	2010-01-25 16:38:59.000000000 +0100
-+++ QPBO-v1.3.src-patched/instances.inc	2013-08-30 15:40:06.838106688 +0200
+--- QPBO-v1.3.src/instances.inc 2010-01-25 10:38:59.000000000 -0500
++++ QPBO-v1.3.src-patched/instances.inc 2016-07-25 14:35:33.253091828 -0400
 @@ -5,30 +5,32 @@
  #endif
  
@@ -267,30 +282,30 @@ diff -rupN QPBO-v1.3.src/instances.inc QPBO-v1.3.src-patched/instances.inc
 +namespace qpbo{
  
  template <> 
- 	inline void QPBO<int>::get_type_information(char*& type_name, char*& type_format)
+    inline void QPBO<int>::get_type_information(char*& type_name, char*& type_format)
  {
--	type_name = "int";
--	type_format = "d";
-+	type_name = (char*)("int");
-+	type_format = (char*)("d");
+-   type_name = "int";
+-   type_format = "d";
++   type_name = (char*)("int");
++   type_format = (char*)("d");
  }
  
  template <> 
- 	inline void QPBO<float>::get_type_information(char*& type_name, char*& type_format)
+    inline void QPBO<float>::get_type_information(char*& type_name, char*& type_format)
  {
--	type_name = "float";
--	type_format = "f";
-+	type_name = (char*)("float");
-+	type_format = (char*)("f");
+-   type_name = "float";
+-   type_format = "f";
++   type_name = (char*)("float");
++   type_format = (char*)("f");
  }
  
  template <> 
- 	inline void QPBO<double>::get_type_information(char*& type_name, char*& type_format)
+    inline void QPBO<double>::get_type_information(char*& type_name, char*& type_format)
  {
--	type_name = "double";
--	type_format = "Lf";
-+	type_name = (char*)("double");
-+	type_format = (char*)("Lf");
+-   type_name = "double";
+-   type_format = "Lf";
++   type_name = (char*)("double");
++   type_format = (char*)("Lf");
  }
  
 +template class QPBO<int>;

--- a/src/interfaces/python/opengm/inference/pyFusionMoves.cxx
+++ b/src/interfaces/python/opengm/inference/pyFusionMoves.cxx
@@ -26,7 +26,7 @@
 #include "opengm/inference/lpcplex.hxx"
 #endif
 #ifdef WITH_QPBO
-#include "QPBO.h"
+#include "opengm/inference/external/qpbo/QPBO.h"
 #endif
 
 


### PR DESCRIPTION
Hello!

This PR is related to an issue that I believe has been in 'TODO status' for some time ([see the conversation here](https://groups.google.com/forum/#!topic/opengm/zraS4IBl5DU)), i.e. add support for the local installation of headers and libraries of external/3rd-party dependencies along with the OpenGM headers. This is a tentative solution which only currently affects the QPBO code, and which could be fairly easily extended to other 3rd party library projects handled in the 'external' directory.

In short, the modifications to the CMakeLists first allow external library headers to be exported to a temporary directory along with other CMake binary outputs, and be installed along with the OpenGM headers later. Due to the change in location of these headers, some #include statements have been updated throughout the project. For QPBO, this means translating all the previously broken "QPBO.h" includes to "opengm/inference/external/qpbo/QPBO.h", which will now be properly resolved when parsed outside the main project. This also required the regeneration of the QPBO code patch for v1.3 of the zip archive, which generates a lot of empty changes (patch of patch, Git has some issues with that it seems).

Next, since most 3rd-party libraries are not header-only, the installation should also comprise their implementation code. This is addressed via a new option in the project's top-level CMakeList ("INSTALL_EXTERNAL_LIB", off by default), which, when activated, will gather the source files of all external libraries into one big library target ("opengm-external"). This target can then be easily exported during installation, and easily parsed by 3rd-party find module scripts.

Overall, while the stats might show that there are a lot of changes in this PR, these are mostly lightweight (patch of patch, and some whitespace cleanup). I personally tested this branch on some of my code which used the QPBO library outside the main project, and did not encounter any issues. 

Also, for those interested, [here](https://github.com/opengm/opengm/files/382668/FindOpenGM.cmake.txt) is a module script I wrote which can be used in other CMake projects to import OpenGM, Gurobi, and CPLEX, as well as the new "opengm-external" library (optionally) all at once.

Let me know if there's anything wrong!
