### PR TITLE
Fixed bug where PYTHON_INSTALL_DIR was not set

### DIFF
--- a/src/interfaces/python/opengm/opengmcore/CMakeLists.txt
+++ b/src/interfaces/python/opengm/opengmcore/CMakeLists.txt
@@ -100,12 +100,6 @@ ELSE()
     SET_TARGET_PROPERTIES(_opengmcore PROPERTIES OUTPUT_NAME "opengmcore"   PREFIX "_")
 ENDIF()
 
-IF(WIN32)
-    INSTALL(TARGETS _opengmcore RUNTIME DESTINATION ${PYTHON_INSTALL_DIR}/opengmcore)
-ELSE()
-    INSTALL(TARGETS _opengmcore LIBRARY DESTINATION ${PYTHON_INSTALL_DIR}/opengmcore)
-ENDIF()
-
 #--------------------------------------------------------------
 # Copy from src to build
 #--------------------------------------------------------------


### PR DESCRIPTION
#### The problem

I was building opengm in my python2.7 virtual environment. I successfully execute the `make` command, but when I went to `make install` it complained that I did not have permission to install to `/_opengmcore.so`. I had set my `CMAKE_LOCAL_PREFIX=~/venv`, so it seemed odd that cmake was trying to install something to the root of my computer.  I decided to investigate the problem. 
#### What I found

In the file `src/interfaces/python/opengm/opengmcore/CMakeLists.txt` there is a block of code which installs the opengm python module 

``` cmake
IF(WIN32)
    INSTALL(TARGETS _opengmcore RUNTIME DESTINATION ${PYTHON_INSTALL_DIR}/opengmcore)
ELSE()
    INSTALL(TARGETS _opengmcore LIBRARY DESTINATION ${PYTHON_INSTALL_DIR}/opengmcore)
ENDIF()
```

However, the `PYTHON_INSTALL_DIR` variable is never set and does not seem to be baked into cmake. In the root CMakeLists.txt I found another install command that had a reasonable destination of 
`"lib/python${PYTHON_VERSION_MAJOR}.${PYTHON_VERSION_MINOR}/site-packages"`. I figured this is what the `PYTHON_INSTALL_DIR` should have been set to. 
#### The fix

Originally I was going to just set `PYTHON_INSTALL_DIR` to the correct value but upon further investigation I noticed that the opengmcore library was actually being installed to the correct location earlier in the program. 

Because it is already being installed somewhere else in the program I simply removed the line. After I did this I deleted my build directory and did a fresh rebuild. Everything seemed to work perfectly. All of the appropriate files were installed to my virtual directory. 
#### questions remaining to be resolved

As long as the special LIBRARY/RUNTIME flags in the install command are doing something I'm unaware of then this simple fix should resolve the issue.  But I'm not exactly sure because I'm not sure  where the other place in the code is that is installing `lib/python2.7/site-packages/opengm/opengmcore/_opengmcore.so`. 
