### PR TITLE
fixes libdai unit test.

### DIFF
--- a/src/unittest/inference/test_libdai.cxx
+++ b/src/unittest/inference/test_libdai.cxx
@@ -45,8 +45,8 @@ void testSumProd(){
    size_t facid1=model.addFactor(fid1,vars1,vars1+2);
    size_t vars[]={0,1};
 
-   JTT::UpdateRule updateRule_jt;// = JTT::UpdateRule::HUGIN;
-   JTT::Heuristic heuristic;//      = JTT::Heuristic::MINFILL;
+   JTT::UpdateRule updateRule_jt = JTT::HUGIN;// = JTT::UpdateRule::HUGIN;
+   JTT::Heuristic heuristic = JTT::MINFILL;//      = JTT::Heuristic::MINFILL;
    JTT::Parameter parameter_jt(updateRule_jt, heuristic,0);
    JTT jt(model, parameter_jt);
 


### PR DESCRIPTION
`test-libdai` cause following error without specifying heuristic and update rule:

```
terminate called after throwing an instance of 'dai::Exception'
  what():  Unknown ENUM value: '' is not in [HUGIN,SHSH] [File include/dai/jtree.h, line 70, function: dai::JTree::Properties::UpdateType::UpdateType(const char*)]
Aborted
```
