### PR TITLE
generate cmake config

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -661,6 +661,12 @@ install(DIRECTORY "${CMAKE_CURRENT_SOURCE_DIR}/include/opengm"
   PATTERN "*.h"
 )
 
+file(WRITE ${CMAKE_BINARY_DIR}/opengmConfig.cmake
+  "set(OPENGM_INCLUDE_DIRS \"${CMAKE_INSTALL_PREFIX}/include\")\n")
+
+install(FILES ${CMAKE_BINARY_DIR}/opengmConfig.cmake
+        DESTINATION lib/cmake/opengm)
+
 #--------------------------------------------------------------
 # test and install opengm python
 #--------------------------------------------------------------


### PR DESCRIPTION
This feature allows downstream projects to use opengm conveniently as shown below

```
cmake_minimum_required(VERSION 3.11)

project(sample)

set(PROJECT_SRCS ${PROJECT_SOURCE_DIR}/main.cpp)

find_package( opengm REQUIRED )

add_executable(${PROJECT_NAME} ${PROJECT_SRCS})

target_include_directories(${PROJECT_NAME} PUBLIC ${OPENGM_INCLUDE_DIRS})
```

for more information about cmake configs please see [here](https://cmake.org/cmake/help/latest/command/find_package.html#full-signature-and-config-mode)